### PR TITLE
fix: 쿠폰 생성 시 필요 없는 필드 삭제 및 id 확인 오류 해결

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode implements BaseCode {
     // 결제 내역/상태/검증 관련
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "주문 금액이 일치하지 않습니다."),
     ALREADY_PROCESSED_OR_CANCELED(HttpStatus.CONFLICT, "이미 처리되었거나 취소된 주문입니다."),
+    ALREADY_PAID(HttpStatus.CONFLICT, "이미 결제가 완료된 예약입니다."),
     ONLY_PAID_CAN_BE_CANCELED(HttpStatus.BAD_REQUEST, "결제 완료 상태의 주문만 취소할 수 있습니다."),
 
     // 결제 내역 존재 관련

--- a/src/main/java/caffeine/nest_dev/domain/coupon/dto/response/UserCouponResponseDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/dto/response/UserCouponResponseDto.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -14,12 +16,23 @@ public class UserCouponResponseDto {
     private final Long couponId;
     private final Long userId;
     private final CouponUseStatus useStatus;
+    
+    // 쿠폰 상세 정보 추가
+    private final String couponName;
+    private final Integer discountAmount;
+    private final LocalDateTime validFrom;
+    private final LocalDateTime validTo;
 
     public static UserCouponResponseDto of(UserCoupon userCoupon) {
         return UserCouponResponseDto.builder()
                 .couponId(userCoupon.getId().getCouponId())
                 .userId(userCoupon.getId().getUserId())
                 .useStatus(userCoupon.getIsUsed())
+                // 쿠폰 상세 정보 추가
+                .couponName(userCoupon.getCoupon().getName())
+                .discountAmount(userCoupon.getCoupon().getDiscountAmount())
+                .validFrom(userCoupon.getCoupon().getValidFrom())
+                .validTo(userCoupon.getCoupon().getValidTo())
                 .build();
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCoupon.java
@@ -29,6 +29,7 @@ public class UserCoupon extends BaseEntity {
     private User user;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private CouponUseStatus isUsed;
 
     public boolean isUsed() {

--- a/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCouponId.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/entity/UserCouponId.java
@@ -13,9 +13,6 @@ import java.io.Serializable;
 @NoArgsConstructor
 @EqualsAndHashCode
 public class UserCouponId implements Serializable {
-
-    private Long value;
-
     @Column(name = "coupon_id")
     private Long couponId;
 

--- a/src/main/java/caffeine/nest_dev/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/repository/UserCouponRepository.java
@@ -5,10 +5,20 @@ import caffeine.nest_dev.domain.coupon.entity.UserCoupon;
 import caffeine.nest_dev.domain.coupon.entity.UserCouponId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface UserCouponRepository extends CrudRepository<UserCoupon, UserCouponId> {
     // FK로 묶인 user_coupon 먼저 삭제
     void deleteByCoupon(Coupon coupon);
+    
     Page<UserCoupon> findAll(Pageable pageable);
+    
+    // 쿠폰 정보를 함께 조회하는 메서드 추가
+    @Query("SELECT uc FROM UserCoupon uc JOIN FETCH uc.coupon WHERE uc.id.userId = :userId")
+    Page<UserCoupon> findByUserIdWithCoupon(Long userId, Pageable pageable);
+    
+    // 모든 사용자 쿠폰을 쿠폰 정보와 함께 조회
+    @Query("SELECT uc FROM UserCoupon uc JOIN FETCH uc.coupon")
+    Page<UserCoupon> findAllWithCoupon(Pageable pageable);
 }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
@@ -34,13 +34,15 @@ public class UserCouponService {
                         ErrorCode.NOT_FOUND_USER_COUPON));
         User user = userService.findByIdAndIsDeletedFalseOrElseThrow(requestDto.getUserId());
         coupon.issue();
-        UserCoupon userCoupon = userCouponRepository.save(requestDto.toEntity(coupon, user));
+        UserCoupon userCoupon = requestDto.toEntity(coupon, user);
+        userCouponRepository.save(userCoupon);
         return UserCouponResponseDto.of(userCoupon);
     }
 
     @Transactional(readOnly = true)
     public PagingResponse<UserCouponResponseDto> getUserCoupon(Pageable pageable) {
-        Page<UserCoupon> pagingResponse = userCouponRepository.findAll(pageable);
+        // 쿠폰 정보를 함께 조회하여 N+1 문제 해결
+        Page<UserCoupon> pagingResponse = userCouponRepository.findAllWithCoupon(pageable);
         Page<UserCouponResponseDto> responseDtos = pagingResponse.map(UserCouponResponseDto::of);
         return PagingResponse.from(responseDtos);
     }


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
>  closes#120
>
>

-  쿠폰 생성 시 필요 없는 필드 삭제 및 id 확인 오류 해결

## 🔎 작업 내용

- entity에 잘못 생성한 필드 삭제

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

---

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

- entity에 잘못 생성한 필드 삭제

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자 쿠폰 응답에 쿠폰명, 할인 금액, 유효 기간(시작/종료일)이 추가되었습니다.
    - 사용자별 및 전체 쿠폰 목록 조회 시 쿠폰 상세 정보를 함께 조회할 수 있습니다.

- **버그 수정**
    - 이미 결제된 예약에 대해 중복 결제가 발생하지 않도록 방지 로직이 추가되었습니다.

- **개선 사항**
    - 쿠폰 사용 상태 컬럼이 데이터베이스에서 반드시 값이 존재하도록 변경되었습니다.
    - 불필요한 필드가 사용자 쿠폰 ID에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->