### PR TITLE
[#124]fix: 유저 쿠폰 사용 시 결제 준비 과정에 적용, 할인 전 원가 금액 entity에 저장

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/payment/controller/PaymentController.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/controller/PaymentController.java
@@ -39,7 +39,7 @@ public class PaymentController {
     public ResponseEntity<CommonResponse<PaymentPrepareResponseDto>> prepare(
             @RequestBody PaymentPrepareRequestDto requestDto,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        String userEmail = userDetails.getEmail();
+        String userEmail = userDetails.getEmail(); 
         PaymentPrepareResponseDto responseDto = paymentService.preparePayment(requestDto,
                 userEmail);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -49,11 +49,10 @@ public class PaymentController {
     @PostMapping("/confirm")
     public ResponseEntity<CommonResponse<PaymentConfirmResponseDto>> confirmPayment(
             @RequestBody PaymentConfirmRequestDto requestDto,
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestParam("reservationId") Long reservationId) {
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
         String userEmail = userDetails.getEmail();
         PaymentConfirmResponseDto responseDto = paymentService.confirmPayment(requestDto, userEmail,
-                reservationId);
+                requestDto.getReservationId());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_PAYMENT_OK, responseDto));
     }

--- a/src/main/java/caffeine/nest_dev/domain/payment/dto/request/PaymentConfirmRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/dto/request/PaymentConfirmRequestDto.java
@@ -3,15 +3,18 @@ package caffeine.nest_dev.domain.payment.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class PaymentConfirmRequestDto {
 
     private String paymentKey;      // 고유 결제 key 값
     private String orderId;         // 주문 번호
     private Integer amount;         // 결제 금액
+    private Long reservationId;     // 예약 ID (프론트엔드에서 전달)
 }

--- a/src/main/java/caffeine/nest_dev/domain/payment/entity/Payment.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/entity/Payment.java
@@ -36,7 +36,9 @@ public class Payment {
 
     private String paymentKey;
 
-    private Integer amount;
+    private Integer amount;          // 최종 결제 금액 (쿠폰 할인 적용 후)
+    private Integer originalAmount;  // 할인 전 원가 (토스 결제 기준)
+    private Integer discountAmount;  // 쿠폰 할인 금액
 
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
@@ -70,10 +72,13 @@ public class Payment {
     private UserCoupon userCoupon;
 
     @Builder
-    public Payment(Reservation reservation, Integer amount, PaymentStatus status, User payer,
+    public Payment(Reservation reservation, Integer amount, Integer originalAmount,
+            Integer discountAmount, PaymentStatus status, User payer,
             Ticket ticket, PaymentType paymentType, String requestedAt, UserCoupon userCoupon) {
         this.reservation = reservation;
         this.amount = amount;
+        this.originalAmount = originalAmount;
+        this.discountAmount = discountAmount;
         this.status = status;
         this.payer = payer;
         this.ticket = ticket;
@@ -99,5 +104,11 @@ public class Payment {
         this.status = PaymentStatus.CANCELED;
         this.cancelReason = reason;
         this.canceledAt = LocalDateTime.now().toString(); // 취소된 시점 기록
+    }
+
+    // 쿠폰 할인 적용 후 최종 금액 업데이트
+    public void updateFinalAmount(Integer finalAmount, Integer discountAmount) {
+        this.amount = finalAmount;
+        this.discountAmount = discountAmount;
     }
 }

--- a/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
@@ -168,7 +168,7 @@ public class PaymentService {
                     // 디버깅을 위해 해당 예약이 존재하는지 확인
                     Optional<Reservation> reservation = reservationRepository.findById(reservationId);
                     if (reservation.isPresent()) {
-                        log.warn("⚠️ 예약은 존재하지만 결제 정보가 없습니다. 예약 ID: {}, 예약 상태: {}", 
+                        log.warn(" 예약은 존재하지만 결제 정보가 없습니다. 예약 ID: {}, 예약 상태: {}",
                                 reservationId, reservation.get().getReservationStatus());
                     } else {
                         log.error(" 예약 자체가 존재하지 않습니다. 예약 ID: {}", reservationId);

--- a/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
@@ -112,8 +112,9 @@ public class PaymentService {
             }
         }
 
-        int finalAmount = requestDto.getAmount();
+        int originalAmount = requestDto.getAmount();
         UserCoupon userCoupon = null;
+        int discountAmount = 0;
 
         if (requestDto.getCouponId() != null) {
             UserCouponId userCouponId = new UserCouponId(user.getId(), requestDto.getCouponId());
@@ -124,27 +125,28 @@ public class PaymentService {
                 throw new BaseException(ErrorCode.COUPON_ALREADY_USED);
             }
 
-            finalAmount -= userCoupon.getCoupon().getDiscountAmount();
-            if (finalAmount < 0) {
-                throw new BaseException(ErrorCode.INVALID_DISCOUNT_AMOUNT); // 음수 방지
+            discountAmount = userCoupon.getCoupon().getDiscountAmount();
+            if (discountAmount > originalAmount) {
+                throw new BaseException(ErrorCode.INVALID_DISCOUNT_AMOUNT); // 할인 금액이 원가보다 클 수 없음
             }
         }
 
-        // 쿠폰Id 로 쿠폰 조회 (null 이 아닐 시 if () 문 타도록)
-        // 쿠폰과 로그인한 유저가 일치하는지 검증
-        // 쿠폰이 사용되었는지 검증
-        // amount - userCoupon.getCoupon.getDiscountAmount() -> 최종 금액
-
-        // 결제 DB 생성 및 저장
-        Payment payment = Payment.builder().reservation(reservation).amount(finalAmount)
-                .status(PaymentStatus.READY) // 결제 대기 상태로 생성
-                .payer(user).ticket(ticket).paymentType(PaymentType.TOSSPAY) // 토스 결제 한정?
-                .userCoupon(userCoupon)
+        // 변경: DB에는 원가 저장, 쿠폰 할인은 결제 승인 시 처리
+        Payment payment = Payment.builder()
+                .reservation(reservation)
+                .amount(originalAmount)          // 원가 저장 (토스 결제 기준)
+                .originalAmount(originalAmount)  // 원가 별도 저장
+                .discountAmount(0)               // 아직 할인 적용 안함
+                .status(PaymentStatus.READY)     // 결제 대기 상태로 생성
+                .payer(user)
+                .ticket(ticket)
+                .paymentType(PaymentType.TOSSPAY)
+                .userCoupon(userCoupon)          // 쿠폰 정보만 연결
                 .build();
         Payment savedPayment = paymentRepository.save(payment);
         
-        log.info("새 결제 생성 완료: reservationId={}, paymentId={}, amount={}", 
-                reservationPk, savedPayment.getId(), finalAmount);
+        log.info("새 결제 생성 완료: reservationId={}, paymentId={}, originalAmount={}, coupon={}", 
+                reservationPk, savedPayment.getId(), originalAmount, userCoupon != null ? "적용" : "없음");
 
         // 예약ID, 티켓명 반환 (프론트 결제창 오픈 등에 사용)
         return new PaymentPrepareResponseDto(String.valueOf(reservation.getId()), ticket.getName());
@@ -154,17 +156,38 @@ public class PaymentService {
     @Transactional
     public PaymentConfirmResponseDto confirmPayment(PaymentConfirmRequestDto requestDto,
             String userEmail, Long reservationId) {
+        
+        log.info(" 결제 승인 요청 시작 - reservationId: {}, userEmail: {}", reservationId, userEmail);
+        log.info(" 결제 승인 요청 데이터: {}", requestDto);
+        
         // 결제 정보 DB 조회
         Payment payment = paymentRepository.findByReservationId(reservationId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_ORDER));
+                .orElseThrow(() -> {
+                    log.error(" 예약 ID {}에 대한 결제 정보를 찾을 수 없습니다", reservationId);
+                    
+                    // 디버깅을 위해 해당 예약이 존재하는지 확인
+                    Optional<Reservation> reservation = reservationRepository.findById(reservationId);
+                    if (reservation.isPresent()) {
+                        log.warn("⚠️ 예약은 존재하지만 결제 정보가 없습니다. 예약 ID: {}, 예약 상태: {}", 
+                                reservationId, reservation.get().getReservationStatus());
+                    } else {
+                        log.error(" 예약 자체가 존재하지 않습니다. 예약 ID: {}", reservationId);
+                    }
+                    
+                    return new BaseException(ErrorCode.NOT_FOUND_ORDER);
+                });
+
+        log.info(" 결제 정보 조회 성공 - paymentId: {}, status: {}", payment.getId(), payment.getStatus());
 
         // 결제자 확인
         if (!payment.getPayer().getEmail().equals(userEmail)) {
             throw new BaseException(ErrorCode.NO_PAYMENT_INFO_AUTHORITY);
         }
 
-        // 결제 금액 확인
-        if (!payment.getAmount().equals(requestDto.getAmount())) {
+        //  원가 기준으로 토스 결제 금액 검증
+        if (!payment.getOriginalAmount().equals(requestDto.getAmount())) {
+            log.error(" 결제 금액 불일치 - DB 원가: {}, 토스 결제: {}",
+                    payment.getOriginalAmount(), requestDto.getAmount());
             throw new BaseException(ErrorCode.INVALID_PAYMENT_AMOUNT);
         }
 
@@ -179,19 +202,34 @@ public class PaymentService {
         // 결제 승인 -> DB 업데이트
         if (tossResponse != null && "DONE".equals(tossResponse.getStatus())) {
             log.info("[결제 승인 성공] orderId: {}", tossResponse.getOrderId());
-            payment.updateOnSuccess(tossResponse.getPaymentKey(), tossResponse.getMethod(),
-                    tossResponse.getApprovedAt(), tossResponse.getRequestedAt());
-
+            
+            // 쿠폰 할인 적용 및 최종 금액 계산
+            int finalAmount = payment.getOriginalAmount(); // 원가부터 시작
+            int discountAmount = 0;
+            
             UserCoupon userCoupon = payment.getUserCoupon();
             if (userCoupon != null) {
                 if (userCoupon.isUsed()) {
                     throw new BaseException(ErrorCode.COUPON_ALREADY_USED);
                 }
-                userCoupon.markAsUsed();
+                
+                discountAmount = userCoupon.getCoupon().getDiscountAmount();
+                finalAmount -= discountAmount; // 쿠폰 할인 적용
+                
+                userCoupon.markAsUsed(); // 쿠폰 사용 처리
+                log.info("🎫 쿠폰 할인 적용 - 원가: {}원, 할인: {}원, 최종: {}원", 
+                        payment.getOriginalAmount(), discountAmount, finalAmount);
             }
-
-            // 쿠폰 조회 (dto 에서 couponId 가져오기)
-            // 쿠폰 상태 업데이트
+            
+            // Payment 업데이트
+            payment.updateOnSuccess(tossResponse.getPaymentKey(), tossResponse.getMethod(),
+                    tossResponse.getApprovedAt(), tossResponse.getRequestedAt());
+            
+            // 최종 금액 및 할인 금액 업데이트
+            payment.updateFinalAmount(finalAmount, discountAmount);
+            
+            log.info(" 결제 완료 - 토스 결제: {}원, 실제 차감: {}원",
+                    payment.getOriginalAmount(), finalAmount);
 
             // 응답 DTO 변환 후 반환
             return PaymentConfirmResponseDto.of(payment);

--- a/src/main/java/caffeine/nest_dev/domain/reservation/dto/request/ReservationRequestDto.java
+++ b/src/main/java/caffeine/nest_dev/domain/reservation/dto/request/ReservationRequestDto.java
@@ -16,9 +16,9 @@ public class ReservationRequestDto {
     private Long mentor;
     private Long ticket;
     private ReservationStatus reservationStatus;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private LocalDateTime reservationStartAt;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private LocalDateTime reservationEndAt;
 
 


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
> closes#124
>

- fix: 유저 쿠폰 사용 시 결제 준비 과정에 적용, 할인 전 원가 금액 entity에 저장

## 🔎 작업 내용

- 유저 쿠폰 사용 시 결제 준비 과정에 적용
- 할인 전 원가 금액 entity에 저장

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.

- 유저 쿠폰 사용 시 결제 준비 과정에 적용
- 할인 전 원가 금액 entity에 저장

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

- 결제 준비 단계 자체에서 할인 금액 적용 가능하도록 작업

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 결제 시 쿠폰 할인 전 금액, 할인 금액, 최종 결제 금액이 각각 별도로 관리됩니다.
  - 결제 승인 단계에서 쿠폰 할인이 적용되어, 결제 금액이 정확하게 반영됩니다.

- **버그 수정**
  - 결제 시 예약 ID가 요청 본문에서 자동으로 처리되어, 별도 파라미터 입력이 필요하지 않습니다.

- **스타일**
  - 예약 요청 시 날짜/시간 형식이 ISO 8601(밀리초 포함)로 변경되어, 일관된 데이터 처리가 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->