### PR TITLE
refactor: 상담가능시간 조회 시 받는 파라미터 값 LocalDate 으로 변경

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/auth/service/AuthService.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/service/AuthService.java
@@ -20,12 +20,6 @@ import caffeine.nest_dev.domain.user.enums.SocialType;
 import caffeine.nest_dev.domain.user.repository.UserRepository;
 import caffeine.nest_dev.domain.user.service.UserService;
 import caffeine.nest_dev.oauth2.userinfo.OAuth2UserInfo;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
-import com.amazonaws.services.simpleemail.model.Body;
-import com.amazonaws.services.simpleemail.model.Content;
-import com.amazonaws.services.simpleemail.model.Destination;
-import com.amazonaws.services.simpleemail.model.Message;
-import com.amazonaws.services.simpleemail.model.SendEmailRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,6 +46,11 @@ public class AuthService {
 
     @Transactional
     public AuthResponseDto signup(AuthRequestDto dto) {
+
+        // 이메일 중복 검증
+        if (userRepository.existsByEmail(dto.getEmail())) {
+            throw new BaseException(ErrorCode.ALREADY_EXIST_EMAIL);
+        }
 
         // 비밀번호 인코딩
         String encoded = passwordEncoder.encode(dto.getPassword());

--- a/src/main/java/caffeine/nest_dev/domain/consultation/controller/ConsultationController.java
+++ b/src/main/java/caffeine/nest_dev/domain/consultation/controller/ConsultationController.java
@@ -7,7 +7,7 @@ import caffeine.nest_dev.domain.consultation.dto.response.AvailableSlotDto;
 import caffeine.nest_dev.domain.consultation.dto.response.ConsultationResponseDto;
 import caffeine.nest_dev.domain.consultation.service.ConsultationService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
-import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -65,10 +65,10 @@ public class ConsultationController {
     @GetMapping("/mentor/{mentorId}/availableConsultations")
     public ResponseEntity<CommonResponse<List<AvailableSlotDto>>> getSlots(
             @PathVariable Long mentorId, // 멘토의 ID
-            @RequestParam DayOfWeek dayOfWeek
+            @RequestParam LocalDate localDate
     ) {
         List<AvailableSlotDto> responseDto = consultationService.getAvailableConsultationSlots(
-                mentorId, dayOfWeek);
+                mentorId, localDate);
         return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_SLOTS_READ, responseDto));
     }
 

--- a/src/main/java/caffeine/nest_dev/domain/consultation/entity/Consultation.java
+++ b/src/main/java/caffeine/nest_dev/domain/consultation/entity/Consultation.java
@@ -43,8 +43,7 @@ public class Consultation extends BaseEntity {
     @Column(nullable = false)
     private LocalTime endAt;
 
-    public void update(DayOfWeek dayOfWeek, LocalTime startAt, LocalTime endAt) {
-        this.dayOfWeek = dayOfWeek;
+    public void update(LocalTime startAt, LocalTime endAt) {
         this.startAt = startAt;
         this.endAt = endAt;
     }

--- a/src/main/java/caffeine/nest_dev/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/reservation/repository/ReservationRepository.java
@@ -34,8 +34,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("endAt") LocalDateTime endAt,
             @Param("canceledStatus") ReservationStatus canceledStatus);
 
-    List<Reservation> findByMentorIdAndReservationStatusNot(Long mentorId,
-            ReservationStatus status);
+    List<Reservation> findByMentorIdAndReservationStatusNotAndReservationStartAtBetween(Long mentorId,
+            ReservationStatus status, LocalDateTime startAt, LocalDateTime endAt);
 
 
     Page<Reservation> findByMentorIdAndReservationStatus(Long userId,


### PR DESCRIPTION
- closes #155 
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

--- 상담가능시간 조회 시 받는 파라미터 값 LocalDate 으로 변경

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

--- DayOfWeek -> LocalDate 로 변경(날짜를 알 수 있게 됨)

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

--- DayOfWeek -> LocalDate 로 변경(날짜를 알 수 있게 됨)

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인