### PR TITLE
[#161] refactor: 유저 쿠폰 동시성 적용

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
@@ -147,7 +147,7 @@ public class PaymentService {
             }
         }
 
-        // 변경: DB에는 원가 저장, 쿠폰 할인은 결제 승인 시 처리
+        // DB에는 원가 저장, 쿠폰 할인은 결제 승인 시 처리
         Payment payment = Payment.builder()
                 .reservation(reservation)
                 .amount(originalAmount)          // 원가 저장 (토스 결제 기준)


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
- closes #161

- refactor: 유저 쿠폰 동시성 적용

## 🔎 작업 내용

- 유저 쿠폰 동시성 적용

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

- @DistributedLock(key = "'coupon-issue:' + #requestDto.couponId")

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 쿠폰 발급 시 동시성 제어를 위해 분산 락이 적용되었습니다.

* **리팩터링**
  * 쿠폰 사용 가능 여부 검증 로직이 쿠폰 엔티티 내부로 일원화되었습니다.

* **스타일**
  * 결제 서비스 내 주석이 정비되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->