### PR TITLE
[#172] refactor: 상담 시간 수정부분 삭제

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/consultation/controller/ConsultationController.java
+++ b/src/main/java/caffeine/nest_dev/domain/consultation/controller/ConsultationController.java
@@ -72,20 +72,6 @@ public class ConsultationController {
         return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_SLOTS_READ, responseDto));
     }
 
-    /**
-     * 상담 시간 수정
-     */
-    @PatchMapping("/mentor/consultations/{consultationId}")
-    public ResponseEntity<CommonResponse<ConsultationResponseDto>> updateConsultation(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable Long consultationId,
-            @RequestBody ConsultationRequestDto requestDto) {
-        ConsultationResponseDto updated = consultationService.updateConsultation(
-                userDetails.getId(), consultationId, requestDto);
-        return ResponseEntity.ok(
-                CommonResponse.of(SuccessCode.SUCCESS_CONSULTATION_UPDATED, updated));
-    }
-
     @DeleteMapping("/mentor/consultations/{consultationId}")
     public ResponseEntity<CommonResponse<Void>> deleteConsultation(
             @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/caffeine/nest_dev/domain/consultation/service/ConsultationService.java
+++ b/src/main/java/caffeine/nest_dev/domain/consultation/service/ConsultationService.java
@@ -104,26 +104,6 @@ public class ConsultationService {
                 .collect(Collectors.toList());
     }
 
-
-    @Transactional
-    public ConsultationResponseDto updateConsultation(Long userId, Long consultationId,
-            ConsultationRequestDto requestDto) {
-
-        if (consultationRepository.existsConsultation(userId, requestDto.getDayOfWeek(),
-                requestDto.getStartAt(),
-                requestDto.getEndAt())) {
-            throw new BaseException(ErrorCode.DUPLICATE_CONSULTATION_TIME);
-        }
-
-        Consultation consultation = consultationRepository.findByIdAndMentorId(consultationId,
-                        userId)
-                .orElseThrow(() -> new BaseException(ErrorCode.CONSULTATION_NOT_FOUND));
-
-        consultation.update(requestDto.getStartAt(), requestDto.getEndAt());
-
-        return ConsultationResponseDto.of(consultation);
-    }
-
     @Transactional
     public void deleteConsultation(Long userId, Long consultationId) {
 


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.

- closes #172

- refactor: 상담 시간 수정부분 삭제

## 🔎 작업 내용

- 상담 시간 수정부분 삭제

## 🛠️ 변경 사항

- 상담 시간 수정부분 삭제

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 기존에 제공되던 상담 시간 수정 기능이 제거되었습니다. 이제 상담 시간은 수정할 수 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->