### PR TITLE
[#174] refactor: 쿠폰 현재 발급된 수량 0 지정

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/coupon/entity/Coupon.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/entity/Coupon.java
@@ -33,7 +33,7 @@ public class Coupon {
     private Integer totalQuantity; // 전체 발급 가능 수량
 
     @Column(nullable = false)
-    private Integer issuedQuantity; // 현재 발급된 수량
+    private Integer issuedQuantity = 0; // 현재 발급된 수량
 
     @Column(nullable = false)
     private LocalDateTime validFrom; // 유효 시작일


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.

- closes #174

- refactor: 쿠폰 현재 발급된 수량 0 지정

## 🔎 작업 내용

- refactor: 쿠폰 현재 발급된 수량 0 지정

## 🛠️ 변경 사항

- private Integer issuedQuantity = 0;

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 쿠폰의 발급 수량 필드가 기본값 0으로 초기화되어, 예기치 않은 값으로 시작되는 문제를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->