### PR TITLE
Feat : 프로필 삭제, 중복 프로필 생성 금지 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,18 @@ configurations {
 repositories {
     mavenCentral()
 }
+
 ext {
     querydslVersion = "6.11" // 안정 버전 사용을 권장합니다.
+    springdocVersion = "2.8.9"
+}
+
+dependencyManagement {
+    dependencies {
+        dependency "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocVersion}"
+        dependency "org.springdoc:springdoc-openapi-starter-webmvc-api:${springdocVersion}"
+        dependency "org.springdoc:springdoc-openapi-starter-common:${springdocVersion}"
+    }
 }
 
 dependencies {
@@ -38,6 +48,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger/OpenAPI Documentation
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocVersion}"
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-api:${springdocVersion}"
+    implementation "org.springdoc:springdoc-openapi-starter-common:${springdocVersion}"
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt:0.12.6'

--- a/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/api/auth/signup", "/api/auth/login", "/ws/**",
             "/oauth2/**", "/api/mentors/recommended-profiles", "/sse/**", "/error",
-            "/oauth2/callback", "/api/auth/signup/**"
+            "/oauth2/callback", "/api/auth/signup/**", "/swagger-ui/**", "/v3/api-docs/**",
+            "/swagger-ui.html"
 
     };
 
@@ -37,7 +38,7 @@ public class SecurityConfig {
             "/api/profiles/*/careers/**", "/api/mentors/profiles", "/api/users/*/profiles/*",
             "/api/complaints", "/api/complaints/*", "/api/keywords", "/api/mentors/*/reviews",
             "/api/ticket", "/api/mentor/*/availableConsultations", "/api/categories", "/api/profiles/*/careers",
-            "/api/users/*", "/api/tickets/*", "/api/reservations",
+            "/api/users/*", "/api/tickets/*", "/api/reservations"
     };
 
     // MENTEE 전용 경로

--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -103,9 +103,13 @@ public enum ErrorCode implements BaseCode {
     // Profile
     PROFILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "프로필이 존재하지 않습니다."),
 
+    PROFILE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 카테고리에 프로필이 등록되어있습니다."),
+
     // Career
     NOT_FOUND_CAREER(HttpStatus.BAD_REQUEST, "경력이 존재하지 않습니다."),
+
     CAREER_CERTIFICATE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "경력 증명서는 최대 3개까지만 등록할 수 있습니다."),
+
     CAREER_CERTIFICATE_EMPTY(HttpStatus.BAD_REQUEST, "경력증명서는 반드시 필요합니다."),
 
     // Certificate
@@ -113,35 +117,46 @@ public enum ErrorCode implements BaseCode {
 
     // OAuth2
     INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "소셜 로그인 타입이 일치하지 않습니다."),
+
     DTO_NOT_FOUND(HttpStatus.BAD_REQUEST, "dto가 존재하지 않습니다."),
+
     INVALID_SOCIAL_CODE(HttpStatus.BAD_REQUEST, "코드가 일치하지 않습니다."),
 
 
     // ChatRoom
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
+
     CHATROOM_NOT_CREATED(HttpStatus.BAD_REQUEST, "결제가 완료된 후 채팅방을 생성할 수 있습니다."),
 
     // Consultation
     CONSULTATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상담 시간은 존재하지 않거나, 접근 권한이 없습니다."),
+
     DUPLICATE_CONSULTATION_TIME(HttpStatus.BAD_REQUEST, "이미 등록되어 있는 시간대 입니다."),
 
     // Answer
     ANSWER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 답변이 등록된 건입니다."),
+
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "답변을 찾을 수 없습니다."),
+
     ANSWER_COMPLAINT_MISMATCH(HttpStatus.BAD_REQUEST, "해당 답변은 선택된 민원에 속하지 않습니다."),
 
 
     // schedule
     CHATROOM_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "예약된 작업이 존재하지 않습니다."),
+
     NOTIFICATION_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "예약된 알림 작업이 존재하지 않습니다."),
+
     DUPLICATED_SCHEDULE(HttpStatus.BAD_REQUEST, "이미 등록된 작업입니다."),
+
     INVALID_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "지정된 예약 시간이 지났습니다."),
+
     CHATROOM_SCHEDULE_REGISTER_FAILED(HttpStatus.BAD_REQUEST, "채팅방 스케줄 등록이 실패했습니다."),
 
     // S3
     S3_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "파일 업로드에 실패하셨습니다."),
 
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다."),
+
     IMAGE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 이미지입니다."),
 
     ;

--- a/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/SuccessCode.java
@@ -87,6 +87,7 @@ public enum SuccessCode implements BaseCode {
     SUCCESS_RECOMMENDED_PROFILE_READ(HttpStatus.OK, "추천 멘토 조회에 성공했습니다."),
     SUCCESS_PROFILE_IMAGE_READ(HttpStatus.OK, "유저의 프로필 이미지 조회 완료"),
     SUCCESS_UPDATE_MAIN_PROFILE(HttpStatus.OK, "메인 프로필이 설정되었습니다."),
+    SUCCESS_PROFILE_DELETED(HttpStatus.OK, "프로필이 삭제되었습니다."),
 
     // Certificate
     SUCCESS_CERTIFICATE_UPDATED(HttpStatus.OK, "경력증명서 수정이 완료되었습니다."),

--- a/src/main/java/caffeine/nest_dev/domain/profile/controller/ProfileController.java
+++ b/src/main/java/caffeine/nest_dev/domain/profile/controller/ProfileController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -115,4 +116,13 @@ public class ProfileController {
         );
     }
 
+    @DeleteMapping("/profiles/{profileId}")
+    public ResponseEntity<CommonResponse<Void>> deleteProfile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long profileId
+    ) {
+        profileService.deleteProfile(userDetails.getId(), profileId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(SuccessCode.SUCCESS_PROFILE_DELETED));
+    }
 }

--- a/src/main/java/caffeine/nest_dev/domain/profile/entity/Profile.java
+++ b/src/main/java/caffeine/nest_dev/domain/profile/entity/Profile.java
@@ -65,4 +65,7 @@ public class Profile extends BaseEntity {
         this.category = category;
     }
 
+    public void deleteProfile() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/caffeine/nest_dev/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/profile/repository/ProfileRepository.java
@@ -9,9 +9,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long>, ProfileRepositoryQuery {
 
-    Page<Profile> findByUserId(Long userId, Pageable pageable);
+    Page<Profile> findByUserIdAndIsDeletedFalse(Long userId, Pageable pageable);
 
     List<Profile> findByUserIdAndIsDeletedFalse(Long userId);
 
-    Optional<Profile> findByUserIdAndCategoryId(Long userId, Long categoryId);
+    Optional<Profile> findByIdAndUserId(Long profileId, Long id);
+
+    boolean existsByUserIdAndCategoryIdAndIsDeletedFalse(Long userId, Long categoryId);
 }

--- a/src/main/java/caffeine/nest_dev/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/caffeine/nest_dev/domain/profile/repository/ProfileRepository.java
@@ -2,6 +2,7 @@ package caffeine.nest_dev.domain.profile.repository;
 
 import caffeine.nest_dev.domain.profile.entity.Profile;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface ProfileRepository extends JpaRepository<Profile, Long>, Profile
     Page<Profile> findByUserId(Long userId, Pageable pageable);
 
     List<Profile> findByUserIdAndIsDeletedFalse(Long userId);
+
+    Optional<Profile> findByUserIdAndCategoryId(Long userId, Long categoryId);
 }

--- a/src/main/java/caffeine/nest_dev/domain/profile/service/ProfileService.java
+++ b/src/main/java/caffeine/nest_dev/domain/profile/service/ProfileService.java
@@ -41,6 +41,10 @@ public class ProfileService {
         Category category = categoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new BaseException(ErrorCode.CATEGORY_NOT_FOUND));
 
+        Long categoryId = category.getId();
+        if (profileRepository.findByUserIdAndCategoryId(userId, categoryId).isPresent()) {
+            throw new BaseException(ErrorCode.PROFILE_ALREADY_EXISTS);
+        }
         // 키워드 조회
         List<Keyword> keywords = keywordRepository.findAllById(requestDto.getKeywordId());
 
@@ -97,7 +101,7 @@ public class ProfileService {
     @Transactional(readOnly = true)
     public List<ProfileResponseDto> searchMentorProfilesByKeyword(String keyword) {
         List<Profile> profiles = profileRepository.searchMentorProfilesByKeyword(keyword);
-        
+
         return profiles.stream()
                 .map(profile -> ProfileResponseDto.from(profile, profile.getUser()))
                 .toList();


### PR DESCRIPTION
- 멘토 프로필 삭제
- 카테고리 하나 당 프로필 1개가 생성되도록 방지
---

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

---

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

---

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

[swagger](http://localhost:8080/swagger-ui/index.html)


---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 프로필 삭제 기능이 추가되었습니다. 이제 프로필을 삭제할 수 있습니다.
  * API 문서(Swagger/OpenAPI) 접근이 인증 없이 가능합니다.

* **버그 수정**
  * 중복된 프로필 생성이 불가능하도록 개선되었습니다.

* **개선 사항**
  * 삭제된 프로필은 목록에서 제외되어 표시됩니다.
  * 다양한 상황에 대한 에러 코드 및 성공 코드가 추가되었습니다.

* **문서화**
  * OpenAPI(Swagger) 문서 지원이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->