### PR TITLE
docs : 스웨거 적용

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
+++ b/src/main/java/caffeine/nest_dev/common/config/SecurityConfig.java
@@ -28,8 +28,9 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/api/auth/signup", "/api/auth/login", "/ws/**",
             "/oauth2/**", "/api/mentors/recommended-profiles", "/sse/**", "/error",
-            "/oauth2/callback", "/api/auth/signup/**", "/actuator/**", "/actuator/prometheus", "/actuator/health", "/actuator/info", "/swagger-ui/**", "/v3/api-docs/**",
-            "/swagger-ui.html"
+            "/oauth2/callback", "/api/auth/signup/**", "/actuator/**", "/actuator/prometheus", "/actuator/health",
+            "/actuator/info", "/swagger-ui/**", "/v3/api-docs/**",
+            "/swagger-ui.html", "/ws-nest/**"
 
 
     };

--- a/src/main/java/caffeine/nest_dev/common/dto/CommonResponse.java
+++ b/src/main/java/caffeine/nest_dev/common/dto/CommonResponse.java
@@ -7,14 +7,14 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public class CommonResponse<T> {
-    private final HttpStatus httpStatus;
+    private final String httpStatus;
     private final String message;
     // null 인 경우 응답에서 제외할 수 있다 (주석처리하면 null 값 포함해서 응답 반환)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T data;
 
     private CommonResponse(HttpStatus httpStatus, String message, T data) {
-        this.httpStatus = httpStatus;
+        this.httpStatus = httpStatus.getReasonPhrase();
         this.message = message;
         this.data = data;
     }

--- a/src/main/java/caffeine/nest_dev/common/websocket/controller/SocketTokenController.java
+++ b/src/main/java/caffeine/nest_dev/common/websocket/controller/SocketTokenController.java
@@ -5,6 +5,10 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.common.websocket.dto.SocketTokenResponseDto;
 import caffeine.nest_dev.common.websocket.service.SocketTokenService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Socket Token", description = "WebSocket 토큰 관리 API")
 @RestController
 @RequiredArgsConstructor
 public class SocketTokenController {
@@ -19,9 +24,11 @@ public class SocketTokenController {
     private final SocketTokenService socketTokenService;
 
     // socket token 발급
+    @Operation(summary = "WebSocket 토큰 발급", description = "WebSocket 연결을 위한 토큰을 발급합니다")
+    @ApiResponse(responseCode = "201", description = "WebSocket 토큰 발급 성공")
     @PostMapping("/socket/token")
     public ResponseEntity<CommonResponse<SocketTokenResponseDto>> createSocketToken(
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         Long userId = userDetails.getId();
         SocketTokenResponseDto responseDto = socketTokenService.createSocketToken(userId);

--- a/src/main/java/caffeine/nest_dev/domain/admin/controller/AdminController.java
+++ b/src/main/java/caffeine/nest_dev/domain/admin/controller/AdminController.java
@@ -6,8 +6,13 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.admin.dto.request.AdminRequestDto;
 import caffeine.nest_dev.domain.admin.dto.response.AdminMentorCareerResponseDto;
 import caffeine.nest_dev.domain.admin.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Admin", description = "관리자 API - 멘토 경력 관리")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -28,6 +34,9 @@ public class AdminController {
     /**
      * 멘토 경력 확인 요청 목록조회
      */
+    @Operation(summary = "멘토 경력 확인 요청 목록 조회", description = "페이징 처리된 멘토 경력 확인 요청 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공적으로 조회됨",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     @GetMapping("/admin/mentor-careers")
     public ResponseEntity<CommonResponse<PagingResponse<AdminMentorCareerResponseDto>>> getMentorCareers(
             Pageable pageable) {
@@ -41,8 +50,12 @@ public class AdminController {
     /**
      * 멘토 경력 확인 요청 단건조회
      */
+    @Operation(summary = "멘토 경력 확인 요청 단건 조회", description = "특정 ID의 멘토 경력 확인 요청을 상세 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "성공적으로 조회됨",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     @GetMapping("/admin/mentor-careers/{careerId}")
     public ResponseEntity<CommonResponse<AdminMentorCareerResponseDto>> getMentorCareerById(
+            @Parameter(description = "조회할 멘토 경력 ID", required = true)
             @PathVariable Long careerId) {
         AdminMentorCareerResponseDto responseDto = adminService.getMentorCareerById(careerId);
         return ResponseEntity.status(HttpStatus.OK)
@@ -53,9 +66,14 @@ public class AdminController {
     /**
      * * 멘토 경력 확인 요청 상태수정
      **/
+    @Operation(summary = "멘토 경력 확인 요청 상태 수정", description = "특정 멘토 경력 확인 요청의 승인/거부 상태를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "상태가 성공적으로 수정됨",
+            content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     @PatchMapping("/admin/mentor-careers/{careerId}/status")
     public ResponseEntity<CommonResponse<Void>> updateMentorCareerStatus(
+            @Parameter(description = "수정할 멘토 경력 ID", required = true)
             @PathVariable Long careerId,
+            @Parameter(description = "상태 수정 요청 데이터", required = true)
             @RequestBody AdminRequestDto adminRequestDto) {
         adminService.updateCareerStatus(careerId, adminRequestDto);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/caffeine/nest_dev/domain/auth/controller/AuthController.java
+++ b/src/main/java/caffeine/nest_dev/domain/auth/controller/AuthController.java
@@ -13,6 +13,10 @@ import caffeine.nest_dev.domain.auth.dto.response.LoginResponseDto;
 import caffeine.nest_dev.domain.auth.dto.response.TokenResponseDto;
 import caffeine.nest_dev.domain.auth.service.AuthService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth", description = "인증 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
@@ -33,9 +38,11 @@ public class AuthController {
     private final AuthService authService;
 
     // 회원가입
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다")
+    @ApiResponse(responseCode = "201", description = "회원가입 성공")
     @PostMapping("/signup")
     public ResponseEntity<CommonResponse<AuthResponseDto>> signup(
-            @Valid @RequestBody AuthRequestDto dto
+            @Parameter(description = "회원가입 요청 정보") @Valid @RequestBody AuthRequestDto dto
     ) {
 
         AuthResponseDto responseDto = authService.signup(dto);
@@ -45,9 +52,11 @@ public class AuthController {
     }
 
     // 인증코드 보내기
+    @Operation(summary = "인증코드 발송", description = "이메일로 인증코드를 발송합니다")
+    @ApiResponse(responseCode = "200", description = "인증코드 발송 성공")
     @PostMapping("/signup/code")
     public ResponseEntity<CommonResponse<Void>> signupCode(
-            @Valid @RequestBody EmailAuthRequestDto dto
+            @Parameter(description = "이메일 인증 요청 정보") @Valid @RequestBody EmailAuthRequestDto dto
     ) {
 
         authService.signupCode(dto);
@@ -57,9 +66,11 @@ public class AuthController {
     }
 
     // 입력받은 인증코드 검증
+    @Operation(summary = "인증코드 검증", description = "입력받은 인증코드를 검증합니다")
+    @ApiResponse(responseCode = "200", description = "인증코드 검증 성공")
     @PostMapping("/signup/code/verify")
     public ResponseEntity<CommonResponse<Void>> verifyCode(
-            @RequestBody AuthCodeRequestDto dto
+            @Parameter(description = "인증코드 검증 요청 정보") @RequestBody AuthCodeRequestDto dto
     ) {
 
         authService.verifyCode(dto);
@@ -69,9 +80,11 @@ public class AuthController {
     }
 
     // 로그인
+    @Operation(summary = "로그인", description = "사용자 로그인을 처리합니다")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
     @PostMapping("/login")
     public ResponseEntity<CommonResponse<LoginResponseDto>> login(
-            @RequestBody LoginRequestDto dto) {
+            @Parameter(description = "로그인 요청 정보") @RequestBody LoginRequestDto dto) {
 
         LoginResponseDto responseDto = authService.login(dto);
 
@@ -80,10 +93,12 @@ public class AuthController {
     }
 
     // 로그아웃
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 처리합니다")
+    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
     @DeleteMapping("/logout")
     public ResponseEntity<CommonResponse<Void>> logout(
-            @RequestHeader("Authorization") String accessToken,
-            @RequestBody LogoutRequestDto dto
+            @Parameter(description = "JWT 액세스 토큰") @RequestHeader("Authorization") String accessToken,
+            @Parameter(description = "로그아웃 요청 정보") @RequestBody LogoutRequestDto dto
     ) {
 
         authService.logout(accessToken, dto.getRefreshToken());
@@ -93,10 +108,12 @@ public class AuthController {
     }
 
     // 토큰 재발급
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다")
+    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공")
     @PostMapping("/token/refresh")
     public ResponseEntity<CommonResponse<TokenResponseDto>> reissue(
-            @RequestBody RefreshTokenRequestDto dto,
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @Parameter(description = "리프레시 토큰 요청 정보") @RequestBody RefreshTokenRequestDto dto,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
 
         TokenResponseDto responseDto = authService.reissue(dto, userDetails.getId());

--- a/src/main/java/caffeine/nest_dev/domain/career/controller/CareerController.java
+++ b/src/main/java/caffeine/nest_dev/domain/career/controller/CareerController.java
@@ -10,6 +10,10 @@ import caffeine.nest_dev.domain.career.dto.response.CareersResponseDto;
 import caffeine.nest_dev.domain.career.dto.response.FindCareerResponseDto;
 import caffeine.nest_dev.domain.career.service.CareerService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "Career", description = "경력 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -36,11 +41,13 @@ public class CareerController {
     private final CareerService careerService;
 
     // 경력 생성
+    @Operation(summary = "경력 생성", description = "프로필에 새로운 경력을 추가합니다")
+    @ApiResponse(responseCode = "201", description = "경력 생성 성공")
     @PostMapping("/profiles/{profileId}/careers")
     public ResponseEntity<CommonResponse<CareerResponseDto>> saveCareer(
-            @RequestPart("dto") CareerRequestDto dto,
-            @RequestPart(value = "files", required = false) List<MultipartFile> files,
-            @PathVariable Long profileId
+            @Parameter(description = "경력 생성 요청 정보") @RequestPart("dto") CareerRequestDto dto,
+            @Parameter(description = "첨부 파일 목록") @RequestPart(value = "files", required = false) List<MultipartFile> files,
+            @Parameter(description = "프로필 ID") @PathVariable Long profileId
     ) {
 
         CareerResponseDto responseDto = careerService.save(dto, profileId, files);
@@ -50,10 +57,12 @@ public class CareerController {
     }
 
     // 경력 상세페이지 조회
+    @Operation(summary = "경력 상세 조회", description = "특정 경력의 상세 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "경력 상세 조회 성공")
     @GetMapping("/profiles/{profileId}/careers/{careerId}")
     public ResponseEntity<CommonResponse<FindCareerResponseDto>> findCareer(
-            @PathVariable Long profileId,
-            @PathVariable Long careerId
+            @Parameter(description = "프로필 ID") @PathVariable Long profileId,
+            @Parameter(description = "경력 ID") @PathVariable Long careerId
     ) {
 
         FindCareerResponseDto responseDto = careerService.findCareer(profileId, careerId);
@@ -63,10 +72,12 @@ public class CareerController {
     }
 
     // 경력 목록 조회
+    @Operation(summary = "프로필별 경력 목록 조회", description = "특정 프로필의 경력 목록을 페이징하여 조회합니다")
+    @ApiResponse(responseCode = "200", description = "경력 목록 조회 성공")
     @GetMapping("/profiles/{profileId}/careers")
     public ResponseEntity<CommonResponse<PagingResponse<CareersResponseDto>>> findCareers(
-            @PathVariable Long profileId,
-            @PageableDefault Pageable pageable
+            @Parameter(description = "프로필 ID") @PathVariable Long profileId,
+            @Parameter(description = "페이지 정보") @PageableDefault Pageable pageable
     ) {
 
         PagingResponse<CareersResponseDto> careers = careerService.findCareers(profileId, pageable);
@@ -76,10 +87,12 @@ public class CareerController {
     }
 
     // 경력 수정
+    @Operation(summary = "경력 수정", description = "기존 경력 정보를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "경력 수정 성공")
     @PatchMapping("/careers/{careerId}")
     public ResponseEntity<CommonResponse<Void>> updateCareer(
-            @PathVariable Long careerId,
-            @RequestBody UpdateCareerRequestDto dto
+            @Parameter(description = "수정할 경력 ID") @PathVariable Long careerId,
+            @Parameter(description = "경력 수정 요청 정보") @RequestBody UpdateCareerRequestDto dto
     ) {
 
         careerService.updateCareer(careerId, dto);
@@ -89,9 +102,11 @@ public class CareerController {
     }
 
     // 경력 삭제
+    @Operation(summary = "경력 삭제", description = "경력 정보를 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "경력 삭제 성공")
     @DeleteMapping("/careers/{careerId}")
     public ResponseEntity<CommonResponse<Void>> deletedCareer(
-            @PathVariable Long careerId
+            @Parameter(description = "삭제할 경력 ID") @PathVariable Long careerId
     ) {
 
         careerService.deleteCareer(careerId);
@@ -101,10 +116,12 @@ public class CareerController {
     }
 
     // 경력 전체 조회
+    @Operation(summary = "전체 경력 조회", description = "인증된 사용자의 모든 경력을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "전체 경력 조회 성공")
     @GetMapping("/careers")
     public ResponseEntity<CommonResponse<PagingResponse<CareersResponseDto>>> findAllCareers(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PageableDefault Pageable pageable
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "페이지 정보") @PageableDefault Pageable pageable
     ) {
         PagingResponse<CareersResponseDto> response = careerService.getCareers(pageable, userDetails);
 

--- a/src/main/java/caffeine/nest_dev/domain/category/controller/CategoryController.java
+++ b/src/main/java/caffeine/nest_dev/domain/category/controller/CategoryController.java
@@ -8,6 +8,10 @@ import caffeine.nest_dev.domain.category.dto.request.CategoryRequestDto;
 import caffeine.nest_dev.domain.category.dto.response.CategoryResponseDto;
 import caffeine.nest_dev.domain.category.service.CategoryService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Category", description = "카테고리 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -30,26 +35,32 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
+    @Operation(summary = "카테고리 생성", description = "관리자가 새로운 카테고리를 생성합니다")
+    @ApiResponse(responseCode = "201", description = "카테고리 생성 성공")
     @PostMapping("/admin/categories")
     public ResponseEntity<CommonResponse<CategoryResponseDto>> createCategory(
-            @RequestBody @Valid CategoryRequestDto categoryRequestDto) {
+            @Parameter(description = "카테고리 생성 요청 정보") @RequestBody @Valid CategoryRequestDto categoryRequestDto) {
         CategoryResponseDto responseDto = categoryService.creatCategory(categoryRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_CATEGORY_CREATED, responseDto));
     }
 
+    @Operation(summary = "카테고리 목록 조회", description = "페이징된 카테고리 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "카테고리 목록 조회 성공")
     @GetMapping("/categories")
     public ResponseEntity<CommonResponse<PagingResponse<CategoryResponseDto>>> getCategories(
-            Pageable pageable) {
+            @Parameter(description = "페이지 정보") Pageable pageable) {
         PagingResponse<CategoryResponseDto> categories = categoryService.getCategories(pageable);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_CATEGORY_READ, categories));
     }
 
+    @Operation(summary = "카테고리 수정", description = "관리자가 기존 카테고리를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "카테고리 수정 성공")
     @PatchMapping("/admin/categories/{categoryId}")
     public ResponseEntity<CommonResponse<CategoryResponseDto>> updateCategory(
-            @PathVariable Long categoryId,
-            @RequestBody @Valid CategoryRequestDto categoryRequestDto
+            @Parameter(description = "수정할 카테고리 ID") @PathVariable Long categoryId,
+            @Parameter(description = "카테고리 수정 요청 정보") @RequestBody @Valid CategoryRequestDto categoryRequestDto
     ) {
         CategoryResponseDto responseDto = categoryService.updateCategory(categoryId,
                 categoryRequestDto);
@@ -58,8 +69,11 @@ public class CategoryController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_CATEGORY_UPDATED, responseDto));
     }
 
+    @Operation(summary = "카테고리 삭제", description = "관리자가 카테고리를 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "카테고리 삭제 성공")
     @DeleteMapping("/admin/categories/{categoryId}")
-    public ResponseEntity<CommonResponse<Void>> deleteCategory(@PathVariable Long categoryId) {
+    public ResponseEntity<CommonResponse<Void>> deleteCategory(
+            @Parameter(description = "삭제할 카테고리 ID") @PathVariable Long categoryId) {
         categoryService.deleteCategory(categoryId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_CATEGORY_DELETED));

--- a/src/main/java/caffeine/nest_dev/domain/certificate/controller/CertificateController.java
+++ b/src/main/java/caffeine/nest_dev/domain/certificate/controller/CertificateController.java
@@ -3,6 +3,10 @@ package caffeine.nest_dev.domain.certificate.controller;
 import caffeine.nest_dev.common.dto.CommonResponse;
 import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.certificate.service.CertificateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "Certificate", description = "경력증명서 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/careers/{careerId}/certificates")
@@ -23,10 +28,12 @@ public class CertificateController {
     private final CertificateService certificateService;
 
     // 경력증명서 수정
+    @Operation(summary = "경력증명서 수정", description = "특정 경력의 증명서 파일을 수정합니다")
+    @ApiResponse(responseCode = "200", description = "경력증명서 수정 성공")
     @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<Void>> updateCertificate(
-            @PathVariable Long careerId,
-            @RequestPart(value = "files") List<MultipartFile> files
+            @Parameter(description = "경력 ID") @PathVariable Long careerId,
+            @Parameter(description = "경력증명서 파일 목록") @RequestPart(value = "files") List<MultipartFile> files
     ) {
 
         certificateService.updateCertificate(careerId, files);

--- a/src/main/java/caffeine/nest_dev/domain/complaint/controller/AdminComplaintController.java
+++ b/src/main/java/caffeine/nest_dev/domain/complaint/controller/AdminComplaintController.java
@@ -9,6 +9,10 @@ import caffeine.nest_dev.domain.complaint.dto.response.AnswerResponseDto;
 import caffeine.nest_dev.domain.complaint.dto.response.ComplaintResponseDto;
 import caffeine.nest_dev.domain.complaint.service.AdminComplaintService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Admin Complaint", description = "관리자 문의/민원 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
@@ -30,11 +35,13 @@ public class AdminComplaintController {
 
     private final AdminComplaintService adminComplaintService;
 
-
+    @Operation(summary = "문의 답변 생성", description = "관리자가 문의에 대한 답변을 작성합니다")
+    @ApiResponse(responseCode = "201", description = "문의 답변 생성 성공")
     @PostMapping("/complaints/{complaintId}/answer")
-    public ResponseEntity<CommonResponse<AnswerResponseDto>> save(@PathVariable Long complaintId,
-            @AuthenticationPrincipal UserDetailsImpl authUser,
-            @RequestBody AnswerRequestDto answerRequestDto
+    public ResponseEntity<CommonResponse<AnswerResponseDto>> save(
+            @Parameter(description = "답변할 문의 ID") @PathVariable Long complaintId,
+            @Parameter(description = "인증된 관리자 정보") @AuthenticationPrincipal UserDetailsImpl authUser,
+            @Parameter(description = "답변 생성 요청 정보") @RequestBody AnswerRequestDto answerRequestDto
     ) {
 
         Long userId = authUser.getId();
@@ -46,9 +53,11 @@ public class AdminComplaintController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_CREATE_ANSWER, answerResponseDto));
     }
 
+    @Operation(summary = "관리자 문의 목록 조회", description = "관리자가 모든 문의 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "관리자 문의 목록 조회 성공")
     @GetMapping("/complaints")
     public ResponseEntity<CommonResponse<PagingResponse<ComplaintResponseDto>>> getAllComplaints(
-            @PageableDefault Pageable pageable) {
+            @Parameter(description = "페이지 정보") @PageableDefault Pageable pageable) {
 
         PagingResponse<ComplaintResponseDto> getAllComplaintsList = adminComplaintService.getAllComplaints(pageable);
 
@@ -56,9 +65,11 @@ public class AdminComplaintController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_SHOW_COMPLAINTS, getAllComplaintsList));
     }
 
+    @Operation(summary = "관리자 문의 상세 조회", description = "관리자가 특정 문의의 상세 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "관리자 문의 상세 조회 성공")
     @GetMapping("/complaints/{complaintId}")
     public ResponseEntity<CommonResponse<ComplaintResponseDto>> getComplaint(
-            @PathVariable Long complaintId) {
+            @Parameter(description = "조회할 문의 ID") @PathVariable Long complaintId) {
 
         ComplaintResponseDto complaint = adminComplaintService.getComplaint(complaintId);
 
@@ -67,20 +78,24 @@ public class AdminComplaintController {
 
     }
 
-
+    @Operation(summary = "관리자 답변 조회", description = "관리자가 특정 문의의 답변을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "관리자 답변 조회 성공")
     @GetMapping("/complaints/{complaintId}/answer")
-    public ResponseEntity<CommonResponse<AnswerResponseDto>> getAnswer(@PathVariable Long complaintId){
+    public ResponseEntity<CommonResponse<AnswerResponseDto>> getAnswer(
+            @Parameter(description = "답변을 조회할 문의 ID") @PathVariable Long complaintId){
         AnswerResponseDto answer = adminComplaintService.getAnswer(complaintId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_SHOW_ANSWER, answer));
     }
 
-
+    @Operation(summary = "답변 수정", description = "관리자가 기존 답변을 수정합니다")
+    @ApiResponse(responseCode = "200", description = "답변 수정 성공")
     @PatchMapping("/answers/{answerId}")
-    public ResponseEntity<CommonResponse<Void>> update(@PathVariable Long answerId,
-            @AuthenticationPrincipal UserDetailsImpl authUser,
-            @RequestBody AnswerUpdateRequestDto answerUpdateRequestDto){
+    public ResponseEntity<CommonResponse<Void>> update(
+            @Parameter(description = "수정할 답변 ID") @PathVariable Long answerId,
+            @Parameter(description = "인증된 관리자 정보") @AuthenticationPrincipal UserDetailsImpl authUser,
+            @Parameter(description = "답변 수정 요청 정보") @RequestBody AnswerUpdateRequestDto answerUpdateRequestDto){
 
         Long userId = authUser.getId();
 

--- a/src/main/java/caffeine/nest_dev/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/caffeine/nest_dev/domain/complaint/controller/ComplaintController.java
@@ -8,6 +8,10 @@ import caffeine.nest_dev.domain.complaint.dto.response.AnswerResponseDto;
 import caffeine.nest_dev.domain.complaint.dto.response.ComplaintResponseDto;
 import caffeine.nest_dev.domain.complaint.service.ComplaintService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Complaint", description = "문의/민원 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -30,11 +35,12 @@ public class ComplaintController {
 
     private final ComplaintService complaintService;
 
-
+    @Operation(summary = "문의 생성", description = "새로운 문의를 등록합니다")
+    @ApiResponse(responseCode = "201", description = "문의 생성 성공")
     @PostMapping("/complaints")
     public ResponseEntity<CommonResponse<ComplaintResponseDto>> save
-            (@RequestBody ComplaintRequestDto complaintRequestDto,
-                    @AuthenticationPrincipal UserDetailsImpl authUser) {
+            (@Parameter(description = "문의 생성 요청 정보") @RequestBody ComplaintRequestDto complaintRequestDto,
+                    @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser) {
 
         Long userId = authUser.getId();
 
@@ -48,9 +54,11 @@ public class ComplaintController {
     /**
      * 문의 목록 조회(다른 사용자들도 조회 가능)
      */
+    @Operation(summary = "전체 문의 목록 조회", description = "모든 사용자의 문의 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "전체 문의 목록 조회 성공")
     @GetMapping("/complaints")
     public ResponseEntity<CommonResponse<PagingResponse<ComplaintResponseDto>>> getInquiries(
-            @PageableDefault(direction = Sort.Direction.DESC)
+            @Parameter(description = "페이지 정보") @PageableDefault(direction = Sort.Direction.DESC)
             Pageable pageable) {
         PagingResponse<ComplaintResponseDto> getComplaintList = complaintService.getInquiries(pageable);
 
@@ -63,9 +71,11 @@ public class ComplaintController {
      * @param complaintId
      * @return
      */
+    @Operation(summary = "문의 상세 조회", description = "특정 문의의 상세 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "문의 상세 조회 성공")
     @GetMapping("/complaints/{complaintId}")
     public ResponseEntity<CommonResponse<ComplaintResponseDto>> getComplaint(
-            @PathVariable Long complaintId) {
+            @Parameter(description = "문의 ID") @PathVariable Long complaintId) {
 
         ComplaintResponseDto complaint = complaintService.getComplaint(complaintId);
 
@@ -76,10 +86,12 @@ public class ComplaintController {
     /**
      * 민원 목록 조회(본인의 민원 목록만)
      */
+    @Operation(summary = "내 문의 목록 조회", description = "인증된 사용자의 문의 목록만 조회합니다")
+    @ApiResponse(responseCode = "200", description = "내 문의 목록 조회 성공")
     @GetMapping("/complaints/myComplaints")
     public ResponseEntity<CommonResponse<PagingResponse<ComplaintResponseDto>>> getMyComplaints(
-            @AuthenticationPrincipal UserDetailsImpl authUser,
-            @PageableDefault(direction = Sort.Direction.DESC)
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser,
+            @Parameter(description = "페이지 정보") @PageableDefault(direction = Sort.Direction.DESC)
             Pageable pageable
     ){
         Long userId = authUser.getId();
@@ -90,9 +102,12 @@ public class ComplaintController {
 
     }
 
+    @Operation(summary = "문의 답변 조회", description = "특정 문의에 대한 답변을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "문의 답변 조회 성공")
     @GetMapping("/complaints/{complaintId}/answer")
-    public ResponseEntity<CommonResponse<AnswerResponseDto>> getAnswer(@PathVariable Long complaintId,
-            @AuthenticationPrincipal UserDetailsImpl authUser){
+    public ResponseEntity<CommonResponse<AnswerResponseDto>> getAnswer(
+            @Parameter(description = "문의 ID") @PathVariable Long complaintId,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser){
 
         AnswerResponseDto answer = complaintService.getAnswer(authUser.getId(), complaintId);
 
@@ -104,10 +119,12 @@ public class ComplaintController {
     /**
      * 민원 삭제(본인의 민원)
      */
+    @Operation(summary = "문의 삭제", description = "본인의 문의를 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "문의 삭제 성공")
     @DeleteMapping("/complaints/{complaintId}")
     public ResponseEntity<CommonResponse<Void>> deleteComplaint(
-            @PathVariable Long complaintId,
-            @AuthenticationPrincipal UserDetailsImpl authUser
+            @Parameter(description = "삭제할 문의 ID") @PathVariable Long complaintId,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser
     ){
         Long id = authUser.getId();
         complaintService.deleteComplaint(id, complaintId);

--- a/src/main/java/caffeine/nest_dev/domain/consultation/controller/ConsultationController.java
+++ b/src/main/java/caffeine/nest_dev/domain/consultation/controller/ConsultationController.java
@@ -7,6 +7,10 @@ import caffeine.nest_dev.domain.consultation.dto.response.AvailableSlotDto;
 import caffeine.nest_dev.domain.consultation.dto.response.ConsultationResponseDto;
 import caffeine.nest_dev.domain.consultation.service.ConsultationService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Consultation", description = "상담 시간 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -33,10 +38,12 @@ public class ConsultationController {
     /**
      * 상감 가능 시간 등록
      */
+    @Operation(summary = "상담 가능 시간 등록", description = "멘토가 상담 가능한 시간을 등록합니다")
+    @ApiResponse(responseCode = "201", description = "상담 가능 시간 등록 성공")
     @PostMapping("/mentor/consultations")
     public ResponseEntity<CommonResponse<ConsultationResponseDto>> createConsultation(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody ConsultationRequestDto consultationRequestDto
+            @Parameter(description = "인증된 멘토 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "상담 시간 등록 요청 정보") @RequestBody ConsultationRequestDto consultationRequestDto
     ) {
         ConsultationResponseDto consultation = consultationService.createConsultation(
                 userDetails.getId(), consultationRequestDto);
@@ -49,9 +56,11 @@ public class ConsultationController {
     /**
      * 내가 등록한 상담 시간 조회
      */
+    @Operation(summary = "내 상담 시간 조회", description = "멘토가 자신이 등록한 상담 시간을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "내 상담 시간 조회 성공")
     @GetMapping("/mentor/consultations")
     public ResponseEntity<CommonResponse<List<ConsultationResponseDto>>> getMyConsultations(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @Parameter(description = "인증된 멘토 정보") @AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<ConsultationResponseDto> myConsultations = consultationService.getMyConsultations(
                 userDetails.getId());
 
@@ -62,20 +71,24 @@ public class ConsultationController {
     /**
      * MENTEE 가 보는 예약된 시간을 제외한 상담 가능한 시간 조회
      */
+    @Operation(summary = "상담 가능 시간 조회", description = "멘티가 특정 멘토의 상담 가능한 시간을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "상담 가능 시간 조회 성공")
     @GetMapping("/mentor/{mentorId}/availableConsultations")
     public ResponseEntity<CommonResponse<List<AvailableSlotDto>>> getSlots(
-            @PathVariable Long mentorId, // 멘토의 ID
-            @RequestParam LocalDate localDate
+            @Parameter(description = "멘토 ID") @PathVariable Long mentorId, // 멘토의 ID
+            @Parameter(description = "조회할 날짜") @RequestParam LocalDate localDate
     ) {
         List<AvailableSlotDto> responseDto = consultationService.getAvailableConsultationSlots(
                 mentorId, localDate);
         return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_SLOTS_READ, responseDto));
     }
 
+    @Operation(summary = "상담 시간 삭제", description = "멘토가 등록한 상담 시간을 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "상담 시간 삭제 성공")
     @DeleteMapping("/mentor/consultations/{consultationId}")
     public ResponseEntity<CommonResponse<Void>> deleteConsultation(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable Long consultationId) {
+            @Parameter(description = "인증된 멘토 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "삭제할 상담 시간 ID") @PathVariable Long consultationId) {
         consultationService.deleteConsultation(userDetails.getId(), consultationId);
         return ResponseEntity.ok(CommonResponse.of(SuccessCode.SUCCESS_CONSULTATION_DELETED));
     }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/controller/AdminCouponController.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/controller/AdminCouponController.java
@@ -6,6 +6,10 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.coupon.dto.request.AdminCouponRequestDto;
 import caffeine.nest_dev.domain.coupon.dto.response.AdminCouponResponseDto;
 import caffeine.nest_dev.domain.coupon.service.AdminCouponService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Admin Coupon", description = "관리자 쿠폰 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/coupons")
@@ -28,37 +33,45 @@ public class AdminCouponController {
 
     private final AdminCouponService adminCouponService;
 
+    @Operation(summary = "쿠폰 등록", description = "관리자가 새로운 쿠폰을 등록합니다")
+    @ApiResponse(responseCode = "201", description = "쿠폰 등록 성공")
     @PostMapping
     public ResponseEntity<CommonResponse<AdminCouponResponseDto>> registerCoupon(
-            @RequestBody AdminCouponRequestDto requestDto
+            @Parameter(description = "쿠폰 등록 요청 정보") @RequestBody AdminCouponRequestDto requestDto
     ) {
         AdminCouponResponseDto responseDto = adminCouponService.saveCoupon(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_ADMIN_COUPON_CREATED, responseDto));
     }
 
+    @Operation(summary = "쿠폰 목록 조회", description = "관리자가 등록된 쿠폰 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "쿠폰 목록 조회 성공")
     @GetMapping
     public ResponseEntity<CommonResponse<PagingResponse<AdminCouponResponseDto>>> findCoupons(
-            @PageableDefault(size = 10, sort = "validTo", direction = Sort.Direction.DESC) Pageable pageable
+            @Parameter(description = "페이지 정보") @PageableDefault(size = 10, sort = "validTo", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         PagingResponse<AdminCouponResponseDto> responseDtos = adminCouponService.getCoupon(pageable);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_ADMIN_COUPON_READ, responseDtos));
     }
 
+    @Operation(summary = "쿠폰 수정", description = "관리자가 기존 쿠폰 정보를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "쿠폰 수정 성공")
     @PatchMapping("/{couponId}")
     public ResponseEntity<CommonResponse<Void>> updateCoupon(
-            @PathVariable Long couponId,
-            @RequestBody AdminCouponRequestDto requestDto
+            @Parameter(description = "수정할 쿠폰 ID") @PathVariable Long couponId,
+            @Parameter(description = "쿠폰 수정 요청 정보") @RequestBody AdminCouponRequestDto requestDto
     ) {
         adminCouponService.modifyCoupon(couponId, requestDto);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_ADMIN_COUPON_UPDATED));
     }
 
+    @Operation(summary = "쿠폰 삭제", description = "관리자가 쿠폰을 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "쿠폰 삭제 성공")
     @DeleteMapping("/{couponId}")
     public ResponseEntity<CommonResponse<Void>> deleteCoupon(
-            @PathVariable Long couponId) {
+            @Parameter(description = "삭제할 쿠폰 ID") @PathVariable Long couponId) {
         adminCouponService.removeCoupon(couponId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_ADMIN_COUPON_DELETED));

--- a/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
@@ -6,6 +6,10 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.coupon.dto.request.UserCouponRequestDto;
 import caffeine.nest_dev.domain.coupon.dto.response.UserCouponResponseDto;
 import caffeine.nest_dev.domain.coupon.service.UserCouponService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "User Coupon", description = "사용자 쿠폰 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user-coupons")
@@ -26,26 +31,32 @@ public class UserCouponController {
 
     private final UserCouponService userCouponService;
 
+    @Operation(summary = "사용자 쿠폰 등록", description = "사용자가 쿠폰을 등록합니다")
+    @ApiResponse(responseCode = "201", description = "사용자 쿠폰 등록 성공")
     @PostMapping
     public ResponseEntity<CommonResponse<UserCouponResponseDto>> registerUserCoupon(
-            @RequestBody UserCouponRequestDto requestDto) {
+            @Parameter(description = "사용자 쿠폰 등록 요청 정보") @RequestBody UserCouponRequestDto requestDto) {
         UserCouponResponseDto responseDto = userCouponService.saveUserCoupon(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_USER_COUPON_CREATED, responseDto));
     }
 
+    @Operation(summary = "사용자 쿠폰 목록 조회", description = "사용자의 쿠폰 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "사용자 쿠폰 목록 조회 성공")
     @GetMapping
     public ResponseEntity<CommonResponse<PagingResponse<UserCouponResponseDto>>> findUserCoupons(
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @Parameter(description = "페이지 정보") @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         PagingResponse<UserCouponResponseDto> responseDtos = userCouponService.getUserCoupon(pageable);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_USER_COUPON_READ, responseDtos));
     }
 
+    @Operation(summary = "쿠폰 사용", description = "사용자가 보유한 쿠폰을 사용합니다")
+    @ApiResponse(responseCode = "200", description = "쿠폰 사용 성공")
     @PatchMapping("/use")
     public ResponseEntity<CommonResponse<Void>> updateUseUserCoupon(
-            @RequestBody UserCouponRequestDto requestDto
+            @Parameter(description = "쿠폰 사용 요청 정보") @RequestBody UserCouponRequestDto requestDto
     ) {
         userCouponService.modifyUserCoupon(requestDto);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/caffeine/nest_dev/domain/keyword/controller/KeywordController.java
+++ b/src/main/java/caffeine/nest_dev/domain/keyword/controller/KeywordController.java
@@ -7,6 +7,10 @@ import caffeine.nest_dev.domain.category.dto.response.CategoryResponseDto;
 import caffeine.nest_dev.domain.keyword.dto.request.KeywordRequestDto;
 import caffeine.nest_dev.domain.keyword.dto.response.KeywordResponseDto;
 import caffeine.nest_dev.domain.keyword.service.KeywordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Keyword", description = "키워드 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -30,26 +35,32 @@ public class KeywordController {
 
     private final KeywordService keywordService;
 
+    @Operation(summary = "키워드 생성", description = "관리자가 새로운 키워드를 생성합니다")
+    @ApiResponse(responseCode = "201", description = "키워드 생성 성공")
     @PostMapping("/admin/keywords")
     public ResponseEntity<CommonResponse<KeywordResponseDto>> createKeyword(
-            @RequestBody KeywordRequestDto keywordRequestDto) {
+            @Parameter(description = "키워드 생성 요청 정보") @RequestBody KeywordRequestDto keywordRequestDto) {
         KeywordResponseDto keyword = keywordService.createKeyword(keywordRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_KEYWORD_CREATED, keyword));
     }
 
+    @Operation(summary = "키워드 목록 조회", description = "등록된 키워드 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "키워드 목록 조회 성공")
     @GetMapping("/keywords")
     public ResponseEntity<CommonResponse<PagingResponse<KeywordResponseDto>>> getKeywords(
-            Pageable pageable) {
+            @Parameter(description = "페이지 정보") Pageable pageable) {
         PagingResponse<KeywordResponseDto> keywords = keywordService.getKeywords(pageable);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_KEYWORD_READ, keywords));
     }
 
+    @Operation(summary = "키워드 수정", description = "관리자가 기존 키워드를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "키워드 수정 성공")
     @PatchMapping("/admin/keywords/{keywordId}")
     public ResponseEntity<CommonResponse<KeywordResponseDto>> updateKeyword(
-            @PathVariable Long keywordId,
-            @RequestBody @Valid KeywordRequestDto keywordRequestDto
+            @Parameter(description = "수정할 키워드 ID") @PathVariable Long keywordId,
+            @Parameter(description = "키워드 수정 요청 정보") @RequestBody @Valid KeywordRequestDto keywordRequestDto
     ) {
         KeywordResponseDto keywordResponseDto = keywordService.updateKeyword(keywordId,
                 keywordRequestDto);
@@ -57,9 +68,11 @@ public class KeywordController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_KEYWORD_UPDATED, keywordResponseDto));
     }
 
+    @Operation(summary = "키워드 삭제", description = "관리자가 키워드를 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "키워드 삭제 성공")
     @DeleteMapping("/admin/keywords/{keywordId}")
     public ResponseEntity<CommonResponse<Void>> deleteKeyword(
-            @PathVariable Long keywordId) {
+            @Parameter(description = "삭제할 키워드 ID") @PathVariable Long keywordId) {
         keywordService.deleteKeyword(keywordId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_KEYWORD_DELETED));
@@ -68,10 +81,12 @@ public class KeywordController {
     /**
      * 키워드 검색
      */
+    @Operation(summary = "키워드 검색", description = "키워드 이름으로 검색합니다")
+    @ApiResponse(responseCode = "200", description = "키워드 검색 성공")
     @GetMapping("/keywords/search")
     public ResponseEntity<CommonResponse<PagingResponse<KeywordResponseDto>>> getKeywords(
-            @RequestParam(required = false) String name,
-            Pageable pageable
+            @Parameter(description = "검색할 키워드 이름") @RequestParam(required = false) String name,
+            @Parameter(description = "페이지 정보") Pageable pageable
     ) {
         PagingResponse<KeywordResponseDto> byName = keywordService.searchKeywords(
                 name, pageable);

--- a/src/main/java/caffeine/nest_dev/domain/message/controller/MessageController.java
+++ b/src/main/java/caffeine/nest_dev/domain/message/controller/MessageController.java
@@ -2,6 +2,9 @@ package caffeine.nest_dev.domain.message.controller;
 
 import caffeine.nest_dev.domain.message.dto.request.MessageRequestDto;
 import caffeine.nest_dev.domain.message.service.MessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +13,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
+@Tag(name = "Message", description = "WebSocket 메시지 API")
 @Slf4j
 @Controller
 @RequiredArgsConstructor
@@ -20,11 +24,12 @@ public class MessageController {
     /**
      * 클라이언트가 메시지를 보내는 경로 ex ) /app/chat_room/{chatRoomId}/message
      */
+    @Operation(summary = "채팅 메시지 전송", description = "WebSocket을 통해 채팅방에 메시지를 전송합니다")
     @MessageMapping("/chat_room/{chatRoomId}/message")
     public void chat(
-            @DestinationVariable Long chatRoomId,
-            Principal principal,
-            @Payload MessageRequestDto requestDto) {
+            @Parameter(description = "채팅방 ID") @DestinationVariable Long chatRoomId,
+            @Parameter(description = "인증된 사용자 정보") Principal principal,
+            @Parameter(description = "메시지 내용") @Payload MessageRequestDto requestDto) {
         String principalName = principal.getName();
         long userId = Long.parseLong(principalName);
 

--- a/src/main/java/caffeine/nest_dev/domain/notification/controller/NotificationController.java
+++ b/src/main/java/caffeine/nest_dev/domain/notification/controller/NotificationController.java
@@ -6,6 +6,10 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.notification.dto.response.NotificationResponseDto;
 import caffeine.nest_dev.domain.notification.service.NotificationService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -27,6 +31,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
  * Last-Event-Id 헤더로 전달하면, 해당 ID 이후의 알림부터 전송합니다.
  * </p>
  */
+@Tag(name = "Notification", description = "실시간 알림 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/sse")
@@ -41,18 +46,23 @@ public class NotificationController {
      * @param lastEventId 클라이언트가 마지막으로 수신한 이벤트 id
      * @return SseEmitter 실시간 알림 스트림 객체
      */
+    @Operation(summary = "SSE 알림 구독", description = "실시간 알림을 받기 위해 SSE 연결을 생성합니다")
+    @ApiResponse(responseCode = "200", description = "SSE 연결 생성 성공")
     @GetMapping(value = "/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestHeader(value = "Last-Event-Id", required = false, defaultValue = "") String lastEventId) {
+    public SseEmitter subscribe(
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "클라이언트가 마지막으로 수신한 이벤트 ID") @RequestHeader(value = "Last-Event-Id", required = false, defaultValue = "") String lastEventId) {
         Long userId = userDetails.getId();
         return notificationService.subscribe(userId, lastEventId);
     }
 
     // 알림 내역 조회
+    @Operation(summary = "알림 내역 조회", description = "사용자의 알림 내역을 페이징하여 조회합니다")
+    @ApiResponse(responseCode = "200", description = "알림 내역 조회 성공")
     @GetMapping("/notifications")
     public ResponseEntity<CommonResponse<PagingResponse<NotificationResponseDto>>> getNotifications(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PageableDefault() Pageable pageable
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "페이지 정보") @PageableDefault() Pageable pageable
     ) {
         PagingResponse<NotificationResponseDto> dtoList = notificationService.getNotifications(userDetails.getId(),
                 pageable);

--- a/src/main/java/caffeine/nest_dev/domain/payment/controller/PaymentController.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/controller/PaymentController.java
@@ -12,6 +12,10 @@ import caffeine.nest_dev.domain.payment.dto.response.PaymentPrepareResponseDto;
 import caffeine.nest_dev.domain.payment.dto.response.PaymentsResponseDto;
 import caffeine.nest_dev.domain.payment.service.PaymentService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Payment", description = "결제 관리 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -35,10 +40,12 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
+    @Operation(summary = "결제 준비", description = "결제를 준비하고 결제 정보를 생성합니다")
+    @ApiResponse(responseCode = "201", description = "결제 준비 성공")
     @PostMapping("/prepare")
     public ResponseEntity<CommonResponse<PaymentPrepareResponseDto>> prepare(
-            @RequestBody PaymentPrepareRequestDto requestDto,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @Parameter(description = "결제 준비 요청 정보") @RequestBody PaymentPrepareRequestDto requestDto,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails) {
         String userEmail = userDetails.getEmail(); 
         PaymentPrepareResponseDto responseDto = paymentService.preparePayment(requestDto,
                 userEmail);
@@ -46,10 +53,12 @@ public class PaymentController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_PAYMENT_PREPARE, responseDto));
     }
 
+    @Operation(summary = "결제 승인", description = "결제를 최종 승인 처리합니다")
+    @ApiResponse(responseCode = "200", description = "결제 승인 성공")
     @PostMapping("/confirm")
     public ResponseEntity<CommonResponse<PaymentConfirmResponseDto>> confirmPayment(
-            @RequestBody PaymentConfirmRequestDto requestDto,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @Parameter(description = "결제 승인 요청 정보") @RequestBody PaymentConfirmRequestDto requestDto,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails) {
         String userEmail = userDetails.getEmail();
         PaymentConfirmResponseDto responseDto = paymentService.confirmPayment(requestDto, userEmail,
                 requestDto.getReservationId());
@@ -57,9 +66,12 @@ public class PaymentController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_PAYMENT_OK, responseDto));
     }
 
+    @Operation(summary = "결제 상세 조회", description = "특정 결제의 상세 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "결제 상세 조회 성공")
     @GetMapping("/{paymentId}")
     public ResponseEntity<CommonResponse<PaymentDetailsResponseDto>> getPaymentDetails(
-            @PathVariable Long paymentId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @Parameter(description = "결제 ID") @PathVariable Long paymentId, 
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails) {
         String userEmail = userDetails.getEmail();
         PaymentDetailsResponseDto responseDto = paymentService.getPaymentDetails(paymentId,
                 userEmail);
@@ -67,10 +79,13 @@ public class PaymentController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_PAYMENT_LIST_READ, responseDto));
     }
 
+    @Operation(summary = "결제 취소", description = "결제를 취소합니다")
+    @ApiResponse(responseCode = "200", description = "결제 취소 성공")
     @PostMapping("/{paymentId}/cancel")
-    public ResponseEntity<CommonResponse<Void>> cancelPayment(@PathVariable Long paymentId,
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody PaymentCancelRequestDto requestDto) {
+    public ResponseEntity<CommonResponse<Void>> cancelPayment(
+            @Parameter(description = "취소할 결제 ID") @PathVariable Long paymentId,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "결제 취소 요청 정보") @RequestBody PaymentCancelRequestDto requestDto) {
         String userEmail = userDetails.getEmail();
         paymentService.cancelPayment(paymentId, requestDto, userEmail);
         return ResponseEntity.status(HttpStatus.OK)
@@ -79,10 +94,12 @@ public class PaymentController {
 
 
     // 결제 내역 조회
+    @Operation(summary = "결제 내역 조회", description = "사용자의 결제 내역을 페이징하여 조회합니다")
+    @ApiResponse(responseCode = "200", description = "결제 내역 조회 성공")
     @GetMapping
     public ResponseEntity<CommonResponse<PagingResponse<PaymentsResponseDto>>> getPayments(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PageableDefault Pageable pageable
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "페이지 정보") @PageableDefault Pageable pageable
     ) {
         PagingResponse<PaymentsResponseDto> payments = paymentService.getPayments(userDetails,
                 pageable);

--- a/src/main/java/caffeine/nest_dev/domain/profile/controller/ProfileController.java
+++ b/src/main/java/caffeine/nest_dev/domain/profile/controller/ProfileController.java
@@ -8,6 +8,10 @@ import caffeine.nest_dev.domain.profile.dto.response.ProfileResponseDto;
 import caffeine.nest_dev.domain.profile.dto.response.RecommendedProfileResponseDto;
 import caffeine.nest_dev.domain.profile.service.ProfileService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Profile", description = "프로필 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -34,10 +39,12 @@ public class ProfileController {
     /**
      * 프로필 생성
      */
+    @Operation(summary = "프로필 생성", description = "새로운 프로필을 생성합니다")
+    @ApiResponse(responseCode = "201", description = "프로필 생성 성공")
     @PostMapping("/profiles")
     public ResponseEntity<CommonResponse<ProfileResponseDto>> createProfile(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody ProfileRequestDto profileRequestDto) {
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "프로필 생성 요청 정보") @RequestBody ProfileRequestDto profileRequestDto) {
         ProfileResponseDto profile = profileService.createProfile(userDetails.getId(),
                 profileRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -47,10 +54,12 @@ public class ProfileController {
     /**
      * 내 프로필 전체조회
      */
+    @Operation(summary = "내 프로필 조회", description = "인증된 사용자의 모든 프로필을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "내 프로필 조회 성공")
     @GetMapping("/profiles/me")
     public ResponseEntity<CommonResponse<PagingResponse<ProfileResponseDto>>> getMyProfiles(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            Pageable pageable
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "페이지 정보") Pageable pageable
     ) {
         PagingResponse<ProfileResponseDto> myProfiles = profileService.getMyProfiles(
                 userDetails.getId(), pageable);
@@ -61,10 +70,12 @@ public class ProfileController {
     /**
      * 프로필 단건 조회
      */
+    @Operation(summary = "프로필 상세 조회", description = "특정 사용자의 특정 프로필을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "프로필 상세 조회 성공")
     @GetMapping("/users/{userId}/profiles/{profileId}")
     public ResponseEntity<CommonResponse<ProfileResponseDto>> getProfile(
-            @PathVariable Long userId,
-            @PathVariable Long profileId
+            @Parameter(description = "사용자 ID") @PathVariable Long userId,
+            @Parameter(description = "프로필 ID") @PathVariable Long profileId
     ) {
         ProfileResponseDto profile = profileService.getProfile(userId, profileId);
 
@@ -75,9 +86,11 @@ public class ProfileController {
     /**
      * 프로필 키워드 검색
      */
+    @Operation(summary = "멘토 프로필 키워드 검색", description = "키워드로 멘토 프로필을 검색합니다")
+    @ApiResponse(responseCode = "200", description = "멘토 프로필 키워드 검색 성공")
     @GetMapping("/mentors/profiles")
     public ResponseEntity<CommonResponse<List<ProfileResponseDto>>> getMentorProfiles(
-            @RequestParam(required = false) String keyword
+            @Parameter(description = "검색 키워드") @RequestParam(required = false) String keyword
     ) {
         List<ProfileResponseDto> profiles = profileService.searchMentorProfilesByKeyword(keyword);
 
@@ -89,9 +102,11 @@ public class ProfileController {
     /**
      * 추천 멘토 조회
      */
+    @Operation(summary = "추천 멘토 조회", description = "카테고리별 추천 멘토를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "추천 멘토 조회 성공")
     @GetMapping("/mentors/recommended-profiles")
     public ResponseEntity<CommonResponse<List<RecommendedProfileResponseDto>>> getRecommendedProfiles(
-            @RequestParam Long categoryId
+            @Parameter(description = "카테고리 ID") @RequestParam Long categoryId
     ) {
         List<RecommendedProfileResponseDto> responseDto = profileService.getRecommendedProfiles(
                 categoryId);
@@ -103,11 +118,13 @@ public class ProfileController {
     /**
      * 프로필 수정
      */
+    @Operation(summary = "프로필 수정", description = "기존 프로필 정보를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "프로필 수정 성공")
     @PatchMapping("/profiles/{profileId}")
     public ResponseEntity<CommonResponse<Void>> updateProfile(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable Long profileId,
-            @RequestBody ProfileRequestDto profileRequestDto) {
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "수정할 프로필 ID") @PathVariable Long profileId,
+            @Parameter(description = "프로필 수정 요청 정보") @RequestBody ProfileRequestDto profileRequestDto) {
 
         profileService.updateProfile(userDetails.getId(), profileId, profileRequestDto);
 
@@ -116,10 +133,12 @@ public class ProfileController {
         );
     }
 
+    @Operation(summary = "프로필 삭제", description = "프로필을 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "프로필 삭제 성공")
     @DeleteMapping("/profiles/{profileId}")
     public ResponseEntity<CommonResponse<Void>> deleteProfile(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PathVariable Long profileId
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "삭제할 프로필 ID") @PathVariable Long profileId
     ) {
         profileService.deleteProfile(userDetails.getId(), profileId);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/caffeine/nest_dev/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/caffeine/nest_dev/domain/reservation/controller/ReservationController.java
@@ -8,6 +8,10 @@ import caffeine.nest_dev.domain.reservation.dto.request.ReservationRequestDto;
 import caffeine.nest_dev.domain.reservation.dto.response.ReservationResponseDto;
 import caffeine.nest_dev.domain.reservation.service.ReservationService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Reservation", description = "예약 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -29,10 +34,12 @@ public class ReservationController {
 
     private final ReservationService reservationService;
 
+    @Operation(summary = "예약 생성", description = "새로운 상담 예약을 생성합니다")
+    @ApiResponse(responseCode = "201", description = "예약 생성 성공")
     @PostMapping("/reservations")
-    public ResponseEntity<CommonResponse<ReservationResponseDto>> save(@RequestBody
-            ReservationRequestDto requestDto,
-            @AuthenticationPrincipal UserDetailsImpl authUser) {
+    public ResponseEntity<CommonResponse<ReservationResponseDto>> save(
+            @Parameter(description = "예약 생성 요청 정보") @RequestBody ReservationRequestDto requestDto,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser) {
 
         Long userId = authUser.getId();
 
@@ -42,10 +49,12 @@ public class ReservationController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_CREATE_RESERVATION, responseDto));
     }
 
+    @Operation(summary = "예약 목록 조회", description = "사용자의 예약 목록을 페이징하여 조회합니다")
+    @ApiResponse(responseCode = "200", description = "예약 목록 조회 성공")
     @GetMapping("/reservations")
     public ResponseEntity<CommonResponse<PagingResponse<ReservationResponseDto>>> getReservationList(
-            @AuthenticationPrincipal UserDetailsImpl authUser,
-            @PageableDefault() Pageable pageable) {
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser,
+            @Parameter(description = "페이지 정보") @PageableDefault() Pageable pageable) {
 
         PagingResponse<ReservationResponseDto> getReservationList = reservationService.getReservationList(
                 authUser.getId(), pageable);
@@ -56,9 +65,12 @@ public class ReservationController {
 
     }
 
+    @Operation(summary = "예약 상세 조회", description = "특정 예약의 상세 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "예약 상세 조회 성공")
     @GetMapping("/reservations/{reservationId}")
     public ResponseEntity<CommonResponse<ReservationResponseDto>> getReservation(
-            @PathVariable Long reservationId, @AuthenticationPrincipal UserDetailsImpl authUser) {
+            @Parameter(description = "조회할 예약 ID") @PathVariable Long reservationId, 
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser) {
 
         Long userId = authUser.getId();
 

--- a/src/main/java/caffeine/nest_dev/domain/review/controller/AdminReviewController.java
+++ b/src/main/java/caffeine/nest_dev/domain/review/controller/AdminReviewController.java
@@ -8,6 +8,10 @@ import caffeine.nest_dev.domain.review.dto.response.ReviewResponseDto;
 import caffeine.nest_dev.domain.review.entity.Review;
 import caffeine.nest_dev.domain.review.enums.ReviewStatus;
 import caffeine.nest_dev.domain.review.service.AdminReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Admin Review", description = "관리자 리뷰 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
@@ -28,9 +33,12 @@ public class AdminReviewController {
 
     private final AdminReviewService adminReviewService;
 
+    @Operation(summary = "관리자 리뷰 목록 조회", description = "관리자가 리뷰 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "관리자 리뷰 목록 조회 성공")
     @GetMapping("/reviews")
     public ResponseEntity<CommonResponse<PagingResponse<ReviewResponseDto>>> getReviewList(
-            @RequestParam(required = false) Long userId, @PageableDefault Pageable pageable) {
+            @Parameter(description = "필터링할 사용자 ID") @RequestParam(required = false) Long userId, 
+            @Parameter(description = "페이지 정보") @PageableDefault Pageable pageable) {
 
         PagingResponse<ReviewResponseDto> getReviewList = adminReviewService.getReviewList(userId,
                 pageable);
@@ -39,9 +47,11 @@ public class AdminReviewController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_SHOW_REVIEWS, getReviewList));
     }
 
+    @Operation(summary = "리뷰 상태 변경", description = "관리자가 리뷰의 상태를 변경합니다 (활성/삭제)")
+    @ApiResponse(responseCode = "200", description = "리뷰 상태 변경 성공")
     @PatchMapping("/reviews/{reviewId}")
     public ResponseEntity<CommonResponse<AdminReviewResponseDto>> changeReviewStatus(
-            @PathVariable Long reviewId) {
+            @Parameter(description = "상태를 변경할 리뷰 ID") @PathVariable Long reviewId) {
 
         Review review = adminReviewService.changeReviewStatus(reviewId);
 

--- a/src/main/java/caffeine/nest_dev/domain/review/controller/ReviewController.java
+++ b/src/main/java/caffeine/nest_dev/domain/review/controller/ReviewController.java
@@ -7,6 +7,10 @@ import caffeine.nest_dev.domain.review.dto.request.ReviewRequestDto;
 import caffeine.nest_dev.domain.review.dto.response.ReviewResponseDto;
 import caffeine.nest_dev.domain.review.service.ReviewService;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Review", description = "리뷰 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -29,10 +34,13 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @Operation(summary = "리뷰 작성", description = "예약에 대한 리뷰를 작성합니다")
+    @ApiResponse(responseCode = "201", description = "리뷰 작성 성공")
     @PostMapping("/reservations/{reservationId}/reviews")
-    public ResponseEntity<CommonResponse<ReviewResponseDto>> save(@PathVariable Long reservationId,
-            @RequestBody ReviewRequestDto reviewRequestDto,
-            @AuthenticationPrincipal UserDetailsImpl authUser) {
+    public ResponseEntity<CommonResponse<ReviewResponseDto>> save(
+            @Parameter(description = "예약 ID") @PathVariable Long reservationId,
+            @Parameter(description = "리뷰 작성 요청 정보") @RequestBody ReviewRequestDto reviewRequestDto,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser) {
 
         Long userId = authUser.getId();
 
@@ -45,9 +53,12 @@ public class ReviewController {
 
 
     // 멘토별 리뷰 목록 조회
+    @Operation(summary = "멘토별 리뷰 조회", description = "특정 멘토의 리뷰 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "멘토별 리뷰 조회 성공")
     @GetMapping("/mentors/{mentorId}/reviews")
     public ResponseEntity<CommonResponse<PagingResponse<ReviewResponseDto>>> getMentorReviews(
-            @PathVariable Long mentorId, @PageableDefault() Pageable pageable) {
+            @Parameter(description = "멘토 ID") @PathVariable Long mentorId, 
+            @Parameter(description = "페이지 정보") @PageableDefault() Pageable pageable) {
 
         PagingResponse<ReviewResponseDto> getMentorReviewList = reviewService.getMentorReviews(
                 mentorId,
@@ -58,10 +69,12 @@ public class ReviewController {
                         getMentorReviewList));
     }
 
+    @Operation(summary = "내 리뷰 조회", description = "사용자가 작성한 리뷰 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "내 리뷰 조회 성공")
     @GetMapping("/reviews")
     public ResponseEntity<CommonResponse<PagingResponse<ReviewResponseDto>>> getMyReviews(
-            @AuthenticationPrincipal UserDetailsImpl authUser,
-            @PageableDefault(page = 0, size = 10) Pageable pageable
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser,
+            @Parameter(description = "페이지 정보") @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
 
         Long userId = authUser.getId();
@@ -74,11 +87,13 @@ public class ReviewController {
                         getMyReviewList));
     }
 
+    @Operation(summary = "리뷰 수정", description = "기존 리뷰를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "리뷰 수정 성공")
     @PatchMapping("/reviews/{reviewId}")
     public ResponseEntity<CommonResponse<Void>> update(
-            @PathVariable Long reviewId,
-            @AuthenticationPrincipal UserDetailsImpl authUser,
-            @RequestBody ReviewRequestDto reviewRequestDto
+            @Parameter(description = "수정할 리뷰 ID") @PathVariable Long reviewId,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl authUser,
+            @Parameter(description = "리뷰 수정 요청 정보") @RequestBody ReviewRequestDto reviewRequestDto
     ) {
         Long userId = authUser.getId();
 
@@ -89,8 +104,11 @@ public class ReviewController {
 
     }
 
+    @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공")
     @DeleteMapping("/reviews/{reviewId}")
-    public ResponseEntity<CommonResponse<Void>> delete(@PathVariable Long reviewId) {
+    public ResponseEntity<CommonResponse<Void>> delete(
+            @Parameter(description = "삭제할 리뷰 ID") @PathVariable Long reviewId) {
 
         reviewService.delete(reviewId);
 

--- a/src/main/java/caffeine/nest_dev/domain/ticket/controller/TicketController.java
+++ b/src/main/java/caffeine/nest_dev/domain/ticket/controller/TicketController.java
@@ -5,6 +5,10 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.ticket.dto.request.TicketRequestDto;
 import caffeine.nest_dev.domain.ticket.dto.response.TicketResponseDto;
 import caffeine.nest_dev.domain.ticket.service.TicketService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Ticket", description = "티켓 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -25,14 +30,18 @@ public class TicketController {
 
     private final TicketService ticketService;
 
+    @Operation(summary = "티켓 등록", description = "관리자가 새로운 티켓을 등록합니다")
+    @ApiResponse(responseCode = "201", description = "티켓 등록 성공")
     @PostMapping("/admin/ticket")
     public ResponseEntity<CommonResponse<TicketResponseDto>> registerTicket(
-            @RequestBody TicketRequestDto requestDto) {
+            @Parameter(description = "티켓 등록 요청 정보") @RequestBody TicketRequestDto requestDto) {
         TicketResponseDto responseDto = ticketService.saveTicket(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_TICKET_CREATED, responseDto));
     }
 
+    @Operation(summary = "티켓 목록 조회", description = "등록된 티켓 목록을 조회합니다")
+    @ApiResponse(responseCode = "200", description = "티켓 목록 조회 성공")
     @GetMapping("/ticket")
     public ResponseEntity<CommonResponse<List<TicketResponseDto>>> findTicketList() {
         List<TicketResponseDto> responseDtos = ticketService.getTicket();
@@ -40,25 +49,32 @@ public class TicketController {
                 .body(CommonResponse.of(SuccessCode.SUCCESS_TICKET_READ, responseDtos));
     }
 
+    @Operation(summary = "티켓 상세 조회", description = "특정 티켓의 상세 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "티켓 상세 조회 성공")
     @GetMapping("/ticket/{ticketId}")
     public ResponseEntity<CommonResponse<TicketResponseDto>> findTicket(
-            @PathVariable Long ticketId) {
+            @Parameter(description = "조회할 티켓 ID") @PathVariable Long ticketId) {
         TicketResponseDto responseDto = ticketService.getTicketById(ticketId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_TICKET_READ, responseDto));
     }
 
+    @Operation(summary = "티켓 수정", description = "관리자가 기존 티켓 정보를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "티켓 수정 성공")
     @PatchMapping("/admin/ticket/{ticketId}")
     public ResponseEntity<CommonResponse<Void>> updateTicket(
-            @PathVariable Long ticketId, @RequestBody TicketRequestDto requestDto) {
+            @Parameter(description = "수정할 티켓 ID") @PathVariable Long ticketId, 
+            @Parameter(description = "티켓 수정 요청 정보") @RequestBody TicketRequestDto requestDto) {
         ticketService.modifyTicket(ticketId, requestDto);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_TICKET_UPDATED));
     }
 
+    @Operation(summary = "티켓 삭제", description = "관리자가 티켓을 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "티켓 삭제 성공")
     @DeleteMapping("/admin/ticket/{ticketId}")
     public ResponseEntity<CommonResponse<Void>> deleteTicket(
-            @PathVariable Long ticketId) {
+            @Parameter(description = "삭제할 티켓 ID") @PathVariable Long ticketId) {
         ticketService.removeTicket(ticketId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_TICKET_DELETED));

--- a/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
+++ b/src/main/java/caffeine/nest_dev/domain/user/controller/UserController.java
@@ -13,6 +13,10 @@ import caffeine.nest_dev.domain.user.dto.response.UserInfoResponseDto;
 import caffeine.nest_dev.domain.user.dto.response.UserResponseDto;
 import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
 import caffeine.nest_dev.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "User", description = "사용자 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
@@ -40,9 +45,11 @@ public class UserController {
     private final UserService userService;
 
     // 마이페이지 조회
+    @Operation(summary = "내 정보 조회", description = "인증된 사용자의 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "내 정보 조회 성공")
     @GetMapping("/me")
     public ResponseEntity<CommonResponse<UserResponseDto>> getUser(
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
 
         UserResponseDto dto = userService.findUser(userDetails.getId());
@@ -52,9 +59,11 @@ public class UserController {
     }
 
     // 유저 조회
+    @Operation(summary = "사용자 정보 조회", description = "특정 사용자의 정보를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공")
     @GetMapping("/{userId}")
     public ResponseEntity<CommonResponse<UserInfoResponseDto>> getUserById(
-            @PathVariable Long userId
+            @Parameter(description = "조회할 사용자 ID") @PathVariable Long userId
     ) {
         UserInfoResponseDto responseDto = userService.getUserById(userId);
 
@@ -63,10 +72,12 @@ public class UserController {
     }
 
     // 정보 수정
+    @Operation(summary = "내 정보 수정", description = "인증된 사용자의 정보를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "내 정보 수정 성공")
     @PatchMapping("/me")
     public ResponseEntity<CommonResponse<Void>> updateUser(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Valid @RequestBody UserRequestDto dto
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "사용자 정보 수정 요청") @Valid @RequestBody UserRequestDto dto
     ) {
 
         userService.updateUser(userDetails.getId(), dto);
@@ -76,10 +87,12 @@ public class UserController {
     }
 
     // 비밀번호 수정
+    @Operation(summary = "비밀번호 수정", description = "사용자의 비밀번호를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "비밀번호 수정 성공")
     @PatchMapping("/me/password")
     public ResponseEntity<CommonResponse<Void>> updatePassword(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Valid @RequestBody UpdatePasswordRequestDto dto
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "비밀번호 수정 요청 정보") @Valid @RequestBody UpdatePasswordRequestDto dto
     ) {
 
         userService.updatePassword(userDetails.getId(), dto);
@@ -89,9 +102,11 @@ public class UserController {
     }
 
     // MENTEE or MENTOR 선택 / 전화번호 입력 (추가정보)
+    @Operation(summary = "추가 정보 입력", description = "사용자 유형(멘토/멘티) 및 전화번호 등 추가 정보를 입력합니다")
+    @ApiResponse(responseCode = "200", description = "추가 정보 입력 성공")
     @PatchMapping("/me/extraInfo")
     public ResponseEntity<CommonResponse<LoginResponseDto>> extraInfo(
-            @Valid @RequestBody ExtraInfoRequestDto dto
+            @Parameter(description = "추가 정보 입력 요청") @Valid @RequestBody ExtraInfoRequestDto dto
     ) {
 
         LoginResponseDto responseDto = userService.updateExtraInfo(dto);
@@ -101,11 +116,13 @@ public class UserController {
     }
 
     // 회원 탈퇴
+    @Operation(summary = "회원 탈퇴", description = "사용자 계정을 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
     @DeleteMapping("/me")
     public ResponseEntity<CommonResponse<Void>> deleteUser(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestHeader("Authorization") String accessToken,
-            @RequestBody DeleteRequestDto dto
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "JWT 액세스 토큰") @RequestHeader("Authorization") String accessToken,
+            @Parameter(description = "회원 탈퇴 요청 정보") @RequestBody DeleteRequestDto dto
     ) {
 
         userService.deleteUser(userDetails.getId(), accessToken, dto);
@@ -115,10 +132,12 @@ public class UserController {
     }
 
     // 이미지 저장
+    @Operation(summary = "프로필 이미지 업로드", description = "사용자의 프로필 이미지를 업로드합니다")
+    @ApiResponse(responseCode = "201", description = "프로필 이미지 업로드 성공")
     @PostMapping("/profile-image")
     public ResponseEntity<CommonResponse<ProfileImageUploadResponseDto>> saveImage(
-            @RequestPart(value = "files", required = false) MultipartFile files,
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @Parameter(description = "업로드할 이미지 파일") @RequestPart(value = "files", required = false) MultipartFile files,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         Long userId = userDetails.getId();
         ProfileImageUploadResponseDto responseDto = userService.saveImg(userId, files);
@@ -128,10 +147,12 @@ public class UserController {
     }
 
     // 이미지 수정
+    @Operation(summary = "프로필 이미지 수정", description = "사용자의 프로필 이미지를 수정합니다")
+    @ApiResponse(responseCode = "200", description = "프로필 이미지 수정 성공")
     @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<ProfileImageUploadResponseDto>> updateImage(
-            @RequestPart(value = "files", required = false) MultipartFile files,
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @Parameter(description = "수정할 이미지 파일") @RequestPart(value = "files", required = false) MultipartFile files,
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         Long userId = userDetails.getId();
         ProfileImageUploadResponseDto responseDto = userService.updateImage(userId, files);
@@ -141,9 +162,11 @@ public class UserController {
     }
 
     // 프로필 이미지 조회 (멘토/멘티)
+    @Operation(summary = "사용자 프로필 이미지 조회", description = "특정 사용자의 프로필 이미지를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "사용자 프로필 이미지 조회 성공")
     @GetMapping("/{userId}/profile-image")
     public ResponseEntity<CommonResponse<ProfileImageResponseDto>> getUserProfileImage(
-            @PathVariable Long userId
+            @Parameter(description = "조회할 사용자 ID") @PathVariable Long userId
     ) {
         ProfileImageResponseDto dto = userService.getUserProfileImage(userId);
         return ResponseEntity.status(HttpStatus.OK)
@@ -152,9 +175,11 @@ public class UserController {
 
 
     // 이미지 삭제
+    @Operation(summary = "프로필 이미지 삭제", description = "사용자의 프로필 이미지를 삭제합니다")
+    @ApiResponse(responseCode = "200", description = "프로필 이미지 삭제 성공")
     @DeleteMapping("/profile-image")
     public ResponseEntity<CommonResponse<Void>> deleteImage(
-            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         Long userId = userDetails.getId();
         userService.deleteImage(userId);

--- a/src/main/java/caffeine/nest_dev/oauth2/controller/OAuth2LoginController.java
+++ b/src/main/java/caffeine/nest_dev/oauth2/controller/OAuth2LoginController.java
@@ -6,6 +6,10 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.user.enums.SocialType;
 import caffeine.nest_dev.oauth2.dto.response.OAuth2LoginResponseDto;
 import caffeine.nest_dev.oauth2.service.OAuth2LoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "OAuth2", description = "소셜 로그인 API")
 @RestController
 @RequiredArgsConstructor
 public class OAuth2LoginController {
@@ -23,10 +28,12 @@ public class OAuth2LoginController {
     private final OAuth2LoginService oAuth2LoginService;
 
     // 로그인 페이지 요청
+    @Operation(summary = "소셜 로그인 페이지 리다이렉트", description = "소셜 로그인 페이지로 리다이렉트합니다")
+    @ApiResponse(responseCode = "200", description = "로그인 페이지 리다이렉트 성공")
     @GetMapping("/oauth2/login/{provider}")
     public void redirectLoginPage(
-            @PathVariable SocialType provider,
-            HttpServletResponse response
+            @Parameter(description = "소셜 로그인 제공자") @PathVariable SocialType provider,
+            @Parameter(description = "HTTP 응답 객체") HttpServletResponse response
     ) throws IOException {
 
         // socialType에 해당하는 로그인 페이지 URL 반환
@@ -37,12 +44,14 @@ public class OAuth2LoginController {
     }
 
     // 소셜 로그인
+    @Operation(summary = "소셜 로그인 콜백 처리", description = "소셜 로그인 인증 코드를 처리합니다")
+    @ApiResponse(responseCode = "200", description = "소셜 로그인 콜백 처리 성공")
     @GetMapping("/oauth2/callback/{provider}")
     public void oauth2Login(
-            @PathVariable SocialType provider,
-            @RequestParam("code") String authorizationCode,
-            @RequestParam("state") String state,
-            HttpServletResponse response
+            @Parameter(description = "소셜 로그인 제공자") @PathVariable SocialType provider,
+            @Parameter(description = "인증 코드") @RequestParam("code") String authorizationCode,
+            @Parameter(description = "상태 값") @RequestParam("state") String state,
+            @Parameter(description = "HTTP 응답 객체") HttpServletResponse response
     ) throws IOException {
 
         String url = oAuth2LoginService.login(provider, authorizationCode,
@@ -52,9 +61,11 @@ public class OAuth2LoginController {
     }
 
     // 소셜 로그인 정보 확인
+    @Operation(summary = "소셜 로그인 정보 확인", description = "소셜 로그인 결과를 확인합니다")
+    @ApiResponse(responseCode = "200", description = "소셜 로그인 정보 확인 성공")
     @GetMapping("/oauth2/callback")
     public ResponseEntity<CommonResponse<OAuth2LoginResponseDto>> oauth2LoginCheck(
-            @RequestParam("code") String code
+            @Parameter(description = "확인 코드") @RequestParam("code") String code
     ) {
         OAuth2LoginResponseDto dto = oAuth2LoginService.loginCheck(code);
 


### PR DESCRIPTION
- 설명만 추가했습니다


---

## 🔎 작업 내용


---

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

---

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 응답에 httpStatus 코드는 저렇게 나오는게 정상이라고합니다!
- 서버 키고 들어가시면 됩니다
- [](http://localhost:8080/swagger-ui/index.html)

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 모든 REST API 컨트롤러에 OpenAPI(Swagger) 어노테이션이 추가되어 API 명세가 대폭 향상되었습니다. 각 엔드포인트 및 파라미터에 대한 설명, 응답 코드, 그룹 태그 등이 문서에 반영됩니다.
* **스타일**
  * 일부 공통 응답 객체의 HTTP 상태 필드 타입이 문자열로 변경되었습니다.
* **기타**
  * 인증 없이 접근 가능한 경로에 WebSocket 관련 경로(`/ws-nest/**`)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->