### PR TITLE
refactor: 유저 쿠폰 조회시 로그인 한 사용자의 목록만 조회하도록 수정

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/controller/UserCouponController.java
@@ -6,6 +6,7 @@ import caffeine.nest_dev.common.enums.SuccessCode;
 import caffeine.nest_dev.domain.coupon.dto.request.UserCouponRequestDto;
 import caffeine.nest_dev.domain.coupon.dto.response.UserCouponResponseDto;
 import caffeine.nest_dev.domain.coupon.service.UserCouponService;
+import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,9 +47,10 @@ public class UserCouponController {
     @ApiResponse(responseCode = "200", description = "사용자 쿠폰 목록 조회 성공")
     @GetMapping
     public ResponseEntity<CommonResponse<PagingResponse<UserCouponResponseDto>>> findUserCoupons(
-            @Parameter(description = "페이지 정보") @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @Parameter(description = "페이지 정보") @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        PagingResponse<UserCouponResponseDto> responseDtos = userCouponService.getUserCoupon(pageable);
+        PagingResponse<UserCouponResponseDto> responseDtos = userCouponService.getUserCoupon(pageable, userDetails);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of(SuccessCode.SUCCESS_USER_COUPON_READ, responseDtos));
     }

--- a/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
+++ b/src/main/java/caffeine/nest_dev/domain/coupon/service/UserCouponService.java
@@ -13,14 +13,14 @@ import caffeine.nest_dev.domain.coupon.repository.AdminCouponRepository;
 import caffeine.nest_dev.domain.coupon.repository.UserCouponRepository;
 import caffeine.nest_dev.domain.reservation.lock.DistributedLock;
 import caffeine.nest_dev.domain.user.entity.User;
+import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
 import caffeine.nest_dev.domain.user.service.UserService;
-import org.springframework.transaction.annotation.Transactional;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.math.BigDecimal;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -36,13 +36,14 @@ public class UserCouponService {
                 .orElseThrow(() -> new BaseException(
                         ErrorCode.NOT_FOUND_USER_COUPON));
         User user = userService.findByIdAndIsDeletedFalseOrElseThrow(requestDto.getUserId());
-        
+
         // 중복 발급 방지 검증
-        UserCouponId userCouponId = new UserCouponId(requestDto.getCouponId(), requestDto.getUserId());
+        UserCouponId userCouponId = new UserCouponId(requestDto.getCouponId(),
+                requestDto.getUserId());
         if (userCouponRepository.existsById(userCouponId)) {
             throw new BaseException(ErrorCode.COUPON_ALREADY_ISSUED);
         }
-        
+
         coupon.issue();
         UserCoupon userCoupon = requestDto.toEntity(coupon, user);
         userCouponRepository.save(userCoupon);
@@ -50,16 +51,19 @@ public class UserCouponService {
     }
 
     @Transactional(readOnly = true)
-    public PagingResponse<UserCouponResponseDto> getUserCoupon(Pageable pageable) {
+    public PagingResponse<UserCouponResponseDto> getUserCoupon(Pageable pageable,
+            UserDetailsImpl userDetails) {
         // 쿠폰 정보를 함께 조회하여 N+1 문제 해결
-        Page<UserCoupon> pagingResponse = userCouponRepository.findAllWithCoupon(pageable);
+        Page<UserCoupon> pagingResponse = userCouponRepository.findByUserIdWithCoupon(
+                userDetails.getId(), pageable);
         Page<UserCouponResponseDto> responseDtos = pagingResponse.map(UserCouponResponseDto::of);
         return PagingResponse.from(responseDtos);
     }
 
     @Transactional
     public void modifyUserCoupon(UserCouponRequestDto requestDto) {
-        UserCouponId userCouponId = new UserCouponId(requestDto.getCouponId(), requestDto.getUserId());
+        UserCouponId userCouponId = new UserCouponId(requestDto.getCouponId(),
+                requestDto.getUserId());
         UserCoupon userCoupon = userCouponRepository.findById(userCouponId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER_COUPON));
         userCoupon.modifyUseStatus(requestDto);
@@ -69,11 +73,12 @@ public class UserCouponService {
         if (orderAmount.compareTo(BigDecimal.valueOf(coupon.getMinOrderAmount())) < 0) {
             throw new BaseException(ErrorCode.COUPON_MIN_ORDER_AMOUNT_NOT_MET);
         }
-        
+
         if (coupon.getDiscountType() == CouponDiscountType.FIXED_AMOUNT) {
             return BigDecimal.valueOf(coupon.getDiscountAmount());
         } else {
-            BigDecimal discountRate = BigDecimal.valueOf(coupon.getDiscountAmount()).divide(BigDecimal.valueOf(100));
+            BigDecimal discountRate = BigDecimal.valueOf(coupon.getDiscountAmount())
+                    .divide(BigDecimal.valueOf(100));
             return orderAmount.multiply(discountRate);
         }
     }


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
>
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

--- 유저 쿠폰 조회시 로그인 한 사용자의 목록만 조회하도록 수정

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

--- 유저 쿠폰 조회시 로그인 한 사용자의 목록만 조회하도록 수정

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

--- 유저 쿠폰 조회시 로그인 한 사용자의 목록만 조회하도록 수정

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인