### PR TITLE
[#190] feat: 결제 시 토스 orderId 저장 및 예약 취소 시 예약 상태 취소로 변경

### DIFF
--- a/src/main/java/caffeine/nest_dev/domain/payment/entity/Payment.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/entity/Payment.java
@@ -36,6 +36,7 @@ public class Payment {
     private Long id;
 
     private String paymentKey;
+    private String orderId;          // 토스 결제 주문 ID
 
     @Column(nullable = false)
     private Integer amount;
@@ -92,9 +93,10 @@ public class Payment {
         this.userCoupon = userCoupon;
     }
 
-    public void updateOnSuccess(String paymentKey, TossPaymentMethod tossPaymentMethod,
+    public void updateOnSuccess(String paymentKey, String orderId, TossPaymentMethod tossPaymentMethod,
             String approvedAt, String requestedAt) {
         this.paymentKey = paymentKey;
+        this.orderId = orderId;
         this.tossPaymentMethod = tossPaymentMethod;
         this.status = PaymentStatus.PAID;
         this.approvedAt = approvedAt;

--- a/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
@@ -254,8 +254,8 @@ public class PaymentService {
             int finalAmount = finalAmountBD.intValue();
 
             // Payment 업데이트
-            payment.updateOnSuccess(tossResponse.getPaymentKey(), tossResponse.getMethod(),
-                    tossResponse.getApprovedAt(), tossResponse.getRequestedAt());
+            payment.updateOnSuccess(tossResponse.getPaymentKey(), tossResponse.getOrderId(), 
+                    tossResponse.getMethod(), tossResponse.getApprovedAt(), tossResponse.getRequestedAt());
 
             // 최종 금액 및 할인 금액 업데이트
             payment.updateFinalAmount(finalAmount, discountAmount);
@@ -369,6 +369,10 @@ public class PaymentService {
                 userCoupon.unmarkAsUsed();
                 log.info("쿠폰 사용 상태 복구 완료 - userCouponId={}", userCoupon.getId());
             }
+
+            Reservation reservation = payment.getReservation();
+            reservation.cancel();
+
         } else {
             log.error("토스 결제 취소에 실패했습니다. paymentKey: {}", payment.getPaymentKey());
             throw new BaseException(ErrorCode.PAYMENT_CANCEL_FAILED);

--- a/src/main/java/caffeine/nest_dev/domain/reservation/entity/Reservation.java
+++ b/src/main/java/caffeine/nest_dev/domain/reservation/entity/Reservation.java
@@ -79,4 +79,8 @@ public class Reservation extends BaseEntity {
         this.reservationStatus = ReservationStatus.COMPLETED;
     }
 
+    public void cancel() {
+        this.reservationStatus = ReservationStatus.CANCELED;
+    }
+
 }


### PR DESCRIPTION
- closes #190

- feat: 결제 시 토스 orderId 저장 및 예약 취소 시 예약 상태 취소로 변경

## 🔎 작업 내용

- 결제 시 토스 orderId 저장 및 예약 취소 시 예약 상태 취소로 변경

## 🛠️ 변경 사항

- 결제 시 토스 orderId 저장
- 예약 취소 시 예약 상태 취소로 변경

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인