### PR TITLE
[#194] Feat/o auth2 결제삭제 시 예약시간 2시간 전까지 가능한 조건 추가

### DIFF
--- a/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
+++ b/src/main/java/caffeine/nest_dev/common/enums/ErrorCode.java
@@ -91,6 +91,7 @@ public enum ErrorCode implements BaseCode {
     PAYMENT_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 취소에 실패했습니다."),
     TOSS_CANCEL_API_FAILED(HttpStatus.BAD_GATEWAY, "Toss API 취소 요청에 실패했습니다."),
     TOSS_API_FAILED(HttpStatus.BAD_GATEWAY, "Toss API 호출에 실패했습니다."),
+    PAYMENT_CANCEL_RESERVATION_EXPIRED(HttpStatus.BAD_REQUEST, "예약 날짜가 지나 결제를 취소할 수 없습니다."),
 
     // Review
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "리뷰가 이미 존재합니다."),

--- a/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
+++ b/src/main/java/caffeine/nest_dev/domain/payment/service/PaymentService.java
@@ -32,6 +32,7 @@ import caffeine.nest_dev.domain.user.entity.UserDetailsImpl;
 import caffeine.nest_dev.domain.user.repository.UserRepository;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
@@ -344,6 +345,10 @@ public class PaymentService {
         // 결제 내역 조회
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new BaseException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getReservation().getReservationStartAt().isAfter(LocalDateTime.now().minusHours(2))) {
+            throw new BaseException(ErrorCode.PAYMENT_CANCEL_RESERVATION_EXPIRED);
+        }
 
         // 본인 결제 확인
         if (!payment.getPayer().getEmail().equals(userEmail)) {


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
- closes #194 
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

--- 결제삭제 시 예약시간 2시간 전까지 가능한 조건 추가

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

--- 결제삭제 시 예약시간 2시간 전까지 가능한 조건 추가

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

--- 결제삭제 시 예약시간 2시간 전까지 가능한 조건 추가

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 예약 시작 시간이 2시간 이내로 임박한 경우, 결제 취소가 불가능하도록 제한되었습니다. 예약 날짜가 지난 경우에도 결제 취소가 불가하다는 안내 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->