### PR TITLE
feat: adminService에서 관리자가 경력 상태 변경할 때 테스트 코드 작성

### DIFF
--- a/src/test/java/caffeine/nest_dev/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/caffeine/nest_dev/domain/admin/service/AdminServiceTest.java
@@ -157,5 +157,29 @@ public class AdminServiceTest {
         verify(careerRepository, times(1)).findByCareerStatus(pageable);
     }
 
+    @Test
+    void updateCareerStatus_shouldNotCallSave_whenOnlyStatusChanged() {
+        //  [Given] 관리자가 특정 Career 상태를 변경하려는 요청이 주어졌을 때
+        // CareerStatus.AUTHORIZED로 상태 변경을 요청하는 DTO 생성
+        AdminRequestDto dto = new AdminRequestDto(CareerStatus.AUTHORIZED);
+
+        // CareerRepository에서 ID 1L인 Career를 조회했을 때 dummyCareer를 반환하도록 mock 설정
+        when(careerRepository.findById(1L)).thenReturn(Optional.of(dummyCareer));
+
+        // [When] 상태 변경 메서드 실행
+        // adminService에서 상태 변경 메서드 호출 (내부적으로 dummyCareer의 상태가 변경됨)
+        adminService.updateCareerStatus(1L, dto);
+
+        // [Then] 검증 단계
+        // careerRepository.findById()는 정확히 1번 호출되었는지 확인
+        verify(careerRepository, times(1)).findById(1L);
+
+        // careerRepository.save()는 한 번도 호출되지 않았는지 확인
+        // 상태 변경이 영속성 컨텍스트 내에서만 일어나고 별도 save 호출이 없음을 검증
+        verify(careerRepository, never()).save(any());
+
+        // 실제 dummyCareer 객체의 상태가 요청한 값으로 변경되었는지 확인
+        assertThat(dummyCareer.getCareerStatus()).isEqualTo(CareerStatus.AUTHORIZED);
+    }
 
 }


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
>
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

---

## 🔎 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

---

## 🛠️ 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
  - `UserService.createUser()` 메서드 추가
  - `@Email` 유효성 검증 적용

---

## 🧩 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
  - 문제: `@Transactional`이 적용되지 않음
  - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
  - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 경력 상태 변경 시 저장 메서드가 호출되지 않음을 검증하는 새로운 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->